### PR TITLE
Change "links" from "lua52" to just "lua"

### DIFF
--- a/lua52-sys/Cargo.toml
+++ b/lua52-sys/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.0.3"
 authors = ["Pierre Krieger <pierre.krieger1708@gmail.com>"]
 description = "Bindings for Lua 5.2"
 build = "build.rs"
-links = "lua52"
+links = "lua"
 license = "MIT"
 repository = "https://github.com/tomaka/rust-hl-lua"
 


### PR DESCRIPTION
Lua versions share function names. It doesn't make sense to link to both lua5.2 and lua5.3 for example.