### PR TITLE
[Breaking change] Make hlua work on stable Rust

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 language: rust
 
-rust: nightly
+rust:
+ - beta # TODO: stable
+ - nightly
 
 env:
   global:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,13 @@
 language: rust
 
 rust:
- - beta # TODO: stable
+ - stable
+ - beta
  - nightly
+
+matrix:
+  allow_failures:
+    - rust: stable
 
 env:
   global:

--- a/README.md
+++ b/README.md
@@ -60,14 +60,14 @@ lua.execute_from_reader::<()>(File::open(&Path::new("script.lua")).unwrap())
 
 #### Writing functions
 
-In order to write a function, you must wrap it around `hlua::function`. This is for the moment a limitation of Rust's inferrence system.
+In order to write a function, you must wrap it around `hlua::functionX` where `X` is the number of parameters. This is for the moment a limitation of Rust's inferrence system.
 
 ```rust
 fn add(a: i32, b: i32) -> i32 {
     a + b
 }
 
-lua.set("add", hlua::function(add));
+lua.set("add", hlua::function2(add));
 lua.execute::<()>("local c = add(2, 4)");   // calls the `add` function above
 let c: i32 = lua.get("c").unwrap();   // returns 6
 ```
@@ -77,7 +77,7 @@ In Lua, functions are exactly like regular variables.
 You can write regular functions as well as closures:
 
 ```rust
-lua.set("mul", hlua::function(|a: i32, b: i32| a * b));
+lua.set("mul", hlua::function2(|a: i32, b: i32| a * b));
 ```
 
 Note that the lifetime of the Lua context must be equal to or shorter than the lifetime of closures. This is enforced at compile-time.
@@ -163,8 +163,8 @@ fn foo() { }
 fn bar() { }
 
 lua.set("mylib", [
-    ("foo", hlua::function(foo)),
-    ("bar", hlua::function(bar))
+    ("foo", hlua::function0(foo)),
+    ("bar", hlua::function0(bar))
 ]);
 
 lua.execute::<()>("mylib.foo()");
@@ -188,7 +188,7 @@ impl<L> hlua::Push<L> for Foo where L: hlua::AsMutLua {
             |mut metatable| {
                 // you can define all the member functions of Foo here
                 // see the official Lua documentation for metatables
-                metatable.set("__call", hlua::function(|| println!("hello from foo")))
+                metatable.set("__call", hlua::function0(|| println!("hello from foo")))
             })
     }
 }

--- a/hlua/examples/sound-api.rs
+++ b/hlua/examples/sound-api.rs
@@ -10,7 +10,7 @@ fn main() {
         let mut sound_namespace = lua.empty_array("Sound");
 
         // creating the `Sound.new` function
-        sound_namespace.set("new", hlua::function(|| Sound::new()));
+        sound_namespace.set("new", hlua::function0(|| Sound::new()));
     }
 
     lua.execute::<()>(r#"
@@ -38,15 +38,15 @@ implement_lua_push!(Sound, |mut metatable| {
     // when the lua code calls `sound:play()`, it will look for `play` in there
     let mut index = metatable.empty_array("__index");
 
-    index.set("play", hlua::function(|snd: &mut Sound| {
+    index.set("play", hlua::function1(|snd: &mut Sound| {
         snd.play()
     }));
 
-    index.set("stop", hlua::function(|snd: &mut Sound| {
+    index.set("stop", hlua::function1(|snd: &mut Sound| {
         snd.stop()
     }));
 
-    index.set("is_playing", hlua::function(|snd: &Sound| {
+    index.set("is_playing", hlua::function1(|snd: &Sound| {
         snd.is_playing()
     }));
 });

--- a/hlua/src/functions_write.rs
+++ b/hlua/src/functions_write.rs
@@ -13,21 +13,124 @@ use std::fmt::Debug;
 use std::mem;
 use std::ptr;
 
-/// Wraps a type that implements `FnMut` so that it can be used by hlua.
-///
-/// This is only needed because of a limitation in Rust's inferrence system.
-pub fn function<F, P>(f: F) -> Function<F, P, <F as FnOnce<P>>::Output> where F: FnMut<P> {
-    Function {
-        function: f,
-        marker: PhantomData,
-    }
+macro_rules! impl_function {
+    ($name:ident $(, $p:ident)*) => (
+        /// Wraps a type that implements `FnMut` so that it can be used by hlua.
+        ///
+        /// This is only needed because of a limitation in Rust's inferrence system.
+        pub fn $name<Z, R $(, $p)*>(f: Z) -> Function<Z, ($($p,)*), R> where Z: FnMut($($p),*) -> R {
+            Function {
+                function: f,
+                marker: PhantomData,
+            }
+        }
+    )
 }
+
+impl_function!(function0);
+impl_function!(function1, A);
+impl_function!(function2, A, B);
+impl_function!(function3, A, B, C);
+impl_function!(function4, A, B, C, D);
+impl_function!(function5, A, B, C, D, E);
+impl_function!(function6, A, B, C, D, E, F);
+impl_function!(function7, A, B, C, D, E, F, G);
+impl_function!(function8, A, B, C, D, E, F, G, H);
+impl_function!(function9, A, B, C, D, E, F, G, H, I);
+impl_function!(function10, A, B, C, D, E, F, G, H, I, J);
 
 /// Opaque type containing a Rust function or closure.
 pub struct Function<F, P, R> {
     function: F,
     marker: PhantomData<(P, R)>,
 }
+
+/// Trait implemented on `Function` to mimic `FnMut`.
+pub trait FunctionExt<P> {
+    type Output;
+
+    fn call_mut(&mut self, params: P) -> Self::Output;
+}
+
+macro_rules! impl_function_ext {
+    () => (
+        impl<Z, R> FunctionExt<()> for Function<Z, (), R> where Z: FnMut() -> R {
+            type Output = R;
+
+            #[allow(non_snake_case)]
+            fn call_mut(&mut self, _: ()) -> Self::Output {
+                (self.function)()
+            }
+        }
+
+        impl<L, Z, R> Push<L> for Function<Z, (), R>
+                where L: AsMutLua,
+                      Z: FnMut() -> R,
+                      R: for<'a> Push<&'a mut InsideCallback> + 'static
+        {
+            fn push_to_lua(self, mut lua: L) -> PushGuard<L> {
+                unsafe {
+                    // pushing the function pointer as a userdata
+                    let lua_data = ffi::lua_newuserdata(lua.as_mut_lua().0,
+                                                        mem::size_of::<Z>() as libc::size_t);
+                    let lua_data: *mut Z = mem::transmute(lua_data);
+                    ptr::write(lua_data, self.function);
+
+                    // pushing wrapper as a closure
+                    let wrapper: extern fn(*mut ffi::lua_State) -> libc::c_int = wrapper::<Self, _, R>;
+                    ffi::lua_pushcclosure(lua.as_mut_lua().0, wrapper, 1);
+                    PushGuard { lua: lua, size: 1 }
+                }
+            }
+        }
+    );
+
+    ($($p:ident),+) => (
+        impl<Z, R $(,$p)*> FunctionExt<($($p,)*)> for Function<Z, ($($p,)*), R> where Z: FnMut($($p),*) -> R {
+            type Output = R;
+
+            #[allow(non_snake_case)]
+            fn call_mut(&mut self, params: ($($p,)*)) -> Self::Output {
+                let ($($p,)*) = params;
+                (self.function)($($p),*)
+            }
+        }
+
+        impl<L, Z, R $(,$p: 'static)+> Push<L> for Function<Z, ($($p,)*), R>
+                where L: AsMutLua,
+                      Z: FnMut($($p),*) -> R,
+                      ($($p,)*): for<'p> LuaRead<&'p mut InsideCallback>,
+                      R: for<'a> Push<&'a mut InsideCallback> + 'static
+        {
+            fn push_to_lua(self, mut lua: L) -> PushGuard<L> {
+                unsafe {
+                    // pushing the function pointer as a userdata
+                    let lua_data = ffi::lua_newuserdata(lua.as_mut_lua().0,
+                                                        mem::size_of::<Z>() as libc::size_t);
+                    let lua_data: *mut Z = mem::transmute(lua_data);
+                    ptr::write(lua_data, self.function);
+
+                    // pushing wrapper as a closure
+                    let wrapper: extern fn(*mut ffi::lua_State) -> libc::c_int = wrapper::<Self, _, R>;
+                    ffi::lua_pushcclosure(lua.as_mut_lua().0, wrapper, 1);
+                    PushGuard { lua: lua, size: 1 }
+                }
+            }
+        }
+    )
+}
+
+impl_function_ext!();
+impl_function_ext!(A);
+impl_function_ext!(A, B);
+impl_function_ext!(A, B, C);
+impl_function_ext!(A, B, C, D);
+impl_function_ext!(A, B, C, D, E);
+impl_function_ext!(A, B, C, D, E, F);
+impl_function_ext!(A, B, C, D, E, F, G);
+impl_function_ext!(A, B, C, D, E, F, G, H);
+impl_function_ext!(A, B, C, D, E, F, G, H, I);
+impl_function_ext!(A, B, C, D, E, F, G, H, I, J);
 
 /// Opaque type that represents the Lua context when inside a callback.
 ///
@@ -55,28 +158,6 @@ unsafe impl<'a> AsMutLua for &'a mut InsideCallback {
     }
 }
 
-impl<L, F, P, R> Push<L> for Function<F, P, R>
-        where L: AsMutLua, P: 'static,
-              F: FnMut<P, Output=R>,
-              P: for<'p> LuaRead<&'p mut InsideCallback>,
-              R: for<'a> Push<&'a mut InsideCallback> + 'static
-{
-    fn push_to_lua(self, mut lua: L) -> PushGuard<L> {
-        unsafe {
-            // pushing the function pointer as a userdata
-            let lua_data = ffi::lua_newuserdata(lua.as_mut_lua().0,
-                                                mem::size_of::<F>() as libc::size_t);
-            let lua_data: *mut F = mem::transmute(lua_data);
-            ptr::write(lua_data, self.function);
-
-            // pushing wrapper as a closure
-            let wrapper: extern fn(*mut ffi::lua_State) -> libc::c_int = wrapper::<F, P, R>;
-            ffi::lua_pushcclosure(lua.as_mut_lua().0, wrapper, 1);
-            PushGuard { lua: lua, size: 1 }
-        }
-    }
-}   
-
 impl<'a, T, E> Push<&'a mut InsideCallback> for Result<T, E>
                 where T: Push<&'a mut InsideCallback> +
                          for<'b> Push<&'b mut &'a mut InsideCallback>,
@@ -97,7 +178,7 @@ impl<'a, T, E> Push<&'a mut InsideCallback> for Result<T, E>
 
 // this function is called when Lua wants to call one of our functions
 extern fn wrapper<T, P, R>(lua: *mut ffi::lua_State) -> libc::c_int
-                           where T: FnMut<P, Output=R>,
+                           where T: FunctionExt<P, Output=R>,
                                  P: for<'p> LuaRead<&'p mut InsideCallback> + 'static,
                                  R: for<'p> Push<&'p mut InsideCallback>
 {

--- a/hlua/src/lib.rs
+++ b/hlua/src/lib.rs
@@ -1,6 +1,3 @@
-#![feature(core)]
-#![feature(unboxed_closures)]
-
 extern crate lua52_sys as ffi;
 extern crate libc;
 
@@ -11,9 +8,10 @@ use std::borrow::Borrow;
 use std::marker::PhantomData;
 
 pub use functions_read::LuaFunction;
-pub use functions_write::{function, InsideCallback};
+pub use functions_write::{Function, InsideCallback};
+pub use functions_write::{function0, function1, function2, function3, function4, function5};
+pub use functions_write::{function6, function7, function8, function9, function10};
 pub use lua_tables::LuaTable;
-
 pub mod any;
 pub mod functions_read;
 pub mod lua_tables;

--- a/hlua/tests/functions_write.rs
+++ b/hlua/tests/functions_write.rs
@@ -5,7 +5,7 @@ fn simple_function() {
     let mut lua = hlua::Lua::new();
 
     fn ret5() -> i32 { 5 };
-    lua.set("ret5", hlua::function(ret5));
+    lua.set("ret5", hlua::function0(ret5));
 
     let val: i32 = lua.execute("return ret5()").unwrap();
     assert_eq!(val, 5);
@@ -16,7 +16,7 @@ fn one_argument() {
     let mut lua = hlua::Lua::new();
 
     fn plus_one(val: i32) -> i32 { val + 1 };
-    lua.set("plus_one", hlua::function(plus_one));
+    lua.set("plus_one", hlua::function1(plus_one));
 
     let val: i32 = lua.execute("return plus_one(3)").unwrap();
     assert_eq!(val, 4);
@@ -27,7 +27,7 @@ fn two_arguments() {
     let mut lua = hlua::Lua::new();
 
     fn add(val1: i32, val2: i32) -> i32 { val1 + val2 };
-    lua.set("add", hlua::function(add));
+    lua.set("add", hlua::function2(add));
 
     let val: i32 = lua.execute("return add(3, 7)").unwrap();
     assert_eq!(val, 10);
@@ -38,7 +38,7 @@ fn wrong_arguments_types() {
     let mut lua = hlua::Lua::new();
 
     fn add(val1: i32, val2: i32) -> i32 { val1 + val2 };
-    lua.set("add", hlua::function(add));
+    lua.set("add", hlua::function2(add));
 
     match lua.execute::<i32>("return add(3, \"hello\")") {
         Err(hlua::LuaError::ExecutionError(_)) => (),
@@ -51,7 +51,7 @@ fn return_result() {
     let mut lua = hlua::Lua::new();
 
     fn always_fails() -> Result<i32, &'static str> { Err("oops, problem") };
-    lua.set("always_fails", hlua::function(always_fails));
+    lua.set("always_fails", hlua::function0(always_fails));
 
     match lua.execute::<()>("always_fails()") {
         Err(hlua::LuaError::ExecutionError(_)) => (),
@@ -63,8 +63,8 @@ fn return_result() {
 fn closures() {
     let mut lua = hlua::Lua::new();
 
-    lua.set("add", hlua::function(|a:i32, b:i32| a + b));
-    lua.set("sub", hlua::function(|a:i32, b:i32| a - b));
+    lua.set("add", hlua::function2(|a:i32, b:i32| a + b));
+    lua.set("sub", hlua::function2(|a:i32, b:i32| a - b));
 
     let val1: i32 = lua.execute("return add(3, 7)").unwrap();
     assert_eq!(val1, 10);
@@ -78,7 +78,7 @@ fn closures_lifetime() {
     fn t<F>(f: F) where F: Fn(i32, i32) -> i32 {
         let mut lua = hlua::Lua::new();
 
-        lua.set("add", hlua::function(f));
+        lua.set("add", hlua::function2(f));
 
         let val1: i32 = lua.execute("return add(3, 7)").unwrap();
         assert_eq!(val1, 10);
@@ -94,7 +94,7 @@ fn closures_extern_access() {
     {
         let mut lua = hlua::Lua::new();
 
-        lua.set("inc", hlua::function(|| a += 1));
+        lua.set("inc", hlua::function0(|| a += 1));
         for _ in (0 .. 15) {
             lua.execute::<()>("inc()").unwrap();
         }

--- a/hlua/tests/lua_tables.rs
+++ b/hlua/tests/lua_tables.rs
@@ -89,7 +89,7 @@ fn metatable() {
 
         let mut metatable = table.get_or_create_metatable();
         fn handler() -> i32 { 5 };
-        metatable.set("__add".to_string(), hlua::function(handler));
+        metatable.set("__add".to_string(), hlua::function0(handler));
     }
 
     let r: i32 = lua.execute("return a + a").unwrap();

--- a/hlua/tests/userdata.rs
+++ b/hlua/tests/userdata.rs
@@ -100,7 +100,7 @@ fn metatables() {
         fn push_to_lua(self, lua: L) -> hlua::PushGuard<L> {
             hlua::userdata::push_userdata(self, lua, |mut table| {
                 table.set("__index".to_string(), vec![
-                    ("test".to_string(), hlua::function(|| 5))
+                    ("test".to_string(), hlua::function0(|| 5))
                 ]);
             })
         }


### PR DESCRIPTION
Replaces `function` with `function0`, `function1`, `function2`, etc. depending on the number of parameters.