### PR TITLE
Update README URLs based on HTTP redirects

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,7 +210,7 @@ To use it, add this to `Cargo.toml`:
 
 ```toml
 [dependencies.rust-hl-lua-modules]
-git = "https://github.com/tomaka/rust-hl-lua"
+git = "https://github.com/tomaka/hlua"
 ```
 
 Then you can use it like this:


### PR DESCRIPTION
Created with https://github.com/dkhamsing/frankenstein

### GitHub Corrected URLs 
Was | Now 
--- | --- 
https://github.com/tomaka/rust-hl-lua | https://github.com/tomaka/hlua 
