### PR TITLE
Fix various warnings from rustc

### DIFF
--- a/hlua/src/lib.rs
+++ b/hlua/src/lib.rs
@@ -81,7 +81,6 @@ pub unsafe trait AsMutLua: AsLua {
 
 /// Opaque type that contains the raw Lua context.
 #[derive(Copy, Clone)]
-#[allow(raw_pointer_derive)]
 pub struct LuaContext(*mut ffi::lua_State);
 unsafe impl Send for LuaContext {}
 

--- a/lua52-sys/src/lib.rs
+++ b/lua52-sys/src/lib.rs
@@ -1,6 +1,7 @@
 #![allow(non_camel_case_types)]
 #![allow(non_snake_case)]
 #![allow(dead_code)]
+#![allow(improper_ctypes)]
 
 extern crate libc;
 


### PR DESCRIPTION
This includes improper_ctypes in lua52-sys, but implemented as #![allow(improper_ctypes)] on the module root. #[allow(improper_ctypes)] on the lua_State struct does not work. If this is merged, #72 should be closed.

It also removes the #[allow(raw_pointer_derive)] from hlua::LuaContext, since that is no longer needed and produces a warning on nightly.

The pr also provides fixes for rust-lang/rust#19925.