### PR TITLE
Fix Functions not properly accepting User Data

### DIFF
--- a/hlua/src/macros.rs
+++ b/hlua/src/macros.rs
@@ -14,15 +14,39 @@ macro_rules! implement_lua_read {
     ($ty:ty) => {
         impl<'s, 'c> hlua::LuaRead<&'c mut hlua::InsideCallback> for &'s mut $ty {
             fn lua_read_at_position(lua: &'c mut hlua::InsideCallback, index: i32) -> Result<&'s mut $ty, &'c mut hlua::InsideCallback> {
-                // FIXME: 
+                // FIXME:
                 unsafe { ::std::mem::transmute($crate::userdata::read_userdata::<$ty>(lua, index)) }
             }
         }
 
         impl<'s, 'c> hlua::LuaRead<&'c mut hlua::InsideCallback> for &'s $ty {
             fn lua_read_at_position(lua: &'c mut hlua::InsideCallback, index: i32) -> Result<&'s $ty, &'c mut hlua::InsideCallback> {
-                // FIXME: 
+                // FIXME:
                 unsafe { ::std::mem::transmute($crate::userdata::read_userdata::<$ty>(lua, index)) }
+            }
+        }
+
+        impl<'s, 'b, 'c> hlua::LuaRead<&'b mut &'c mut hlua::InsideCallback> for &'s mut $ty {
+            fn lua_read_at_position(lua: &'b mut &'c mut hlua::InsideCallback, index: i32) -> Result<&'s mut $ty, &'b mut &'c mut hlua::InsideCallback> {
+                let ptr_lua = lua as *mut &mut hlua::InsideCallback;
+                let deref_lua = unsafe { ::std::ptr::read(ptr_lua) };
+                let res = Self::lua_read_at_position(deref_lua, index);
+                match res {
+                    Ok(x) => Ok(x),
+                    _ => Err(lua)
+                }
+            }
+        }
+
+        impl<'s, 'b, 'c> hlua::LuaRead<&'b mut &'c mut hlua::InsideCallback> for &'s $ty {
+            fn lua_read_at_position(lua: &'b mut &'c mut hlua::InsideCallback, index: i32) -> Result<&'s $ty, &'b mut &'c mut hlua::InsideCallback> {
+                let ptr_lua = lua as *mut &mut hlua::InsideCallback;
+                let deref_lua = unsafe { ::std::ptr::read(ptr_lua) };
+                let res = Self::lua_read_at_position(deref_lua, index);
+                match res {
+                    Ok(x) => Ok(x),
+                    _ => Err(lua)
+                }
             }
         }
     };

--- a/hlua/src/userdata.rs
+++ b/hlua/src/userdata.rs
@@ -99,17 +99,15 @@ pub fn read_userdata<'t, 'c, T>(mut lua: &'c mut InsideCallback, index: i32)
                                 -> Result<&'t mut T, &'c mut InsideCallback>
                                 where T: 'static + Any
 {
-    assert!(index == -1);   // FIXME:
-
     unsafe {
         let expected_typeid = format!("{:?}", TypeId::of::<T>());
 
-        let data_ptr = ffi::lua_touserdata(lua.as_lua().0, -1);
+        let data_ptr = ffi::lua_touserdata(lua.as_lua().0, index);
         if data_ptr.is_null() {
             return Err(lua);
         }
 
-        if ffi::lua_getmetatable(lua.as_lua().0, -1) == 0 {
+        if ffi::lua_getmetatable(lua.as_lua().0, index) == 0 {
             return Err(lua);
         }
 
@@ -121,7 +119,7 @@ pub fn read_userdata<'t, 'c, T>(mut lua: &'c mut InsideCallback, index: i32)
                 return Err(lua);
             }
         }
-        ffi::lua_pop(lua.as_lua().0, -2);
+        ffi::lua_pop(lua.as_lua().0, 2);
 
         Ok(mem::transmute(data_ptr))
     }
@@ -135,17 +133,15 @@ pub struct UserdataOnStack<T, L> {
 
 impl<T, L> LuaRead<L> for UserdataOnStack<T, L> where L: AsMutLua + AsLua, T: 'static + Any {
     fn lua_read_at_position(mut lua: L, index: i32) -> Result<UserdataOnStack<T, L>, L> {
-        assert!(index == -1);   // FIXME:
-
         unsafe {
             let expected_typeid = format!("{:?}", TypeId::of::<T>());
 
-            let data_ptr = ffi::lua_touserdata(lua.as_lua().0, -1);
+            let data_ptr = ffi::lua_touserdata(lua.as_lua().0, index);
             if data_ptr.is_null() {
                 return Err(lua);
             }
 
-            if ffi::lua_getmetatable(lua.as_lua().0, -1) == 0 {
+            if ffi::lua_getmetatable(lua.as_lua().0, index) == 0 {
                 return Err(lua);
             }
 
@@ -157,7 +153,7 @@ impl<T, L> LuaRead<L> for UserdataOnStack<T, L> where L: AsMutLua + AsLua, T: 's
                     return Err(lua);
                 }
             }
-            ffi::lua_pop(lua.as_lua().0, -2);
+            ffi::lua_pop(lua.as_lua().0, 2);
 
             Ok(UserdataOnStack {
                 variable: lua,


### PR DESCRIPTION
This fixes a bug where functions could never be used with both User Data and standard types. The previous implementation was only able to handle User Data being the first parameter and even asserted that only 1 parameter was being used. The new implementation is dynamic over the index and works with any combination of User Data and standard types.

Fixes #75
