### PR TITLE
Tables can be in any argument position for Rust functions

### DIFF
--- a/hlua/src/lua_tables.rs
+++ b/hlua/src/lua_tables.rs
@@ -31,6 +31,7 @@ unsafe impl<L> AsMutLua for LuaTable<L> where L: AsMutLua {
 
 impl<L> LuaRead<L> for LuaTable<L> where L: AsMutLua {
     fn lua_read_at_position(mut lua: L, index: i32) -> Result<LuaTable<L>, L> {
+        assert!(index < 0); // FIXME:
         if unsafe { ffi::lua_istable(lua.as_mut_lua().0, index) } {
             Ok(LuaTable { table: lua, index: index })
         } else {


### PR DESCRIPTION
Tables now have an index field, which keeps track of where they are in the lua stack, and the lua FFI functions are now offset relative to this index (when relevant.)

This is my first pull request on Github, and I know only as much about the Lua C API as I skimmed in the past hour or so, but I ran this through a small gauntlet of tests with Rust FFI functions accepting multiple user-data types that are pushed to and read from Lua as tables, and it seems to work. (My data types are all just vectors and matrices and such, though, so no nested tables. It may be worth giving a try with those if you have some on hand.)

Thanks!