### PR TITLE
Fix closures that can outlive environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,7 +182,7 @@ This is usually done by redirecting the call to `userdata::push_userdata`.
 ```rust
 struct Foo;
 
-impl<L> hlua::Push<L> for Foo where L: hlua::AsMutLua {
+impl<L> hlua::Push<L> for Foo where L: hlua::AsMutLua<'lua> {
     fn push_to_lua(self, lua: L) -> hlua::PushGuard<L> {
         lua::userdata::push_userdata(self, lua,
             |mut metatable| {

--- a/hlua/src/any.rs
+++ b/hlua/src/any.rs
@@ -21,11 +21,12 @@ pub enum AnyLuaValue {
     LuaOther,
 }
 
-impl<L> Push<L> for AnyLuaValue
-    where L: AsMutLua
+impl<'lua, L> Push<L> for AnyLuaValue
+    where L: AsMutLua<'lua>
 {
     #[inline]
     fn push_to_lua(self, mut lua: L) -> PushGuard<L> {
+        let raw_lua = lua.as_lua();
         match self {
             AnyLuaValue::LuaString(val) => val.push_to_lua(lua),
             AnyLuaValue::LuaNumber(val) => val.push_to_lua(lua),
@@ -38,6 +39,7 @@ impl<L> Push<L> for AnyLuaValue
                 PushGuard {
                     lua: lua,
                     size: 1,
+                    raw_lua: raw_lua,
                 }
             } // Use ffi::lua_pushnil.
             AnyLuaValue::LuaOther => panic!("can't push a AnyLuaValue of type Other"),
@@ -45,8 +47,8 @@ impl<L> Push<L> for AnyLuaValue
     }
 }
 
-impl<L> LuaRead<L> for AnyLuaValue
-    where L: AsLua
+impl<'lua, L> LuaRead<L> for AnyLuaValue
+    where L: AsLua<'lua>
 {
     #[inline]
     fn lua_read_at_position(lua: L, index: i32) -> Result<AnyLuaValue, L> {

--- a/hlua/src/macros.rs
+++ b/hlua/src/macros.rs
@@ -1,7 +1,7 @@
 #[macro_export]
 macro_rules! implement_lua_push {
     ($ty:ty, $cb:expr) => {
-        impl<L> $crate::Push<L> for $ty where L: $crate::AsMutLua {
+        impl<'lua, L> $crate::Push<L> for $ty where L: $crate::AsMutLua<'lua> {
             #[inline]
             fn push_to_lua(self, lua: L) -> $crate::PushGuard<L> {
                 $crate::userdata::push_userdata(self, lua, $cb)

--- a/hlua/src/rust_tables.rs
+++ b/hlua/src/rust_tables.rs
@@ -8,8 +8,8 @@ use std::collections::{HashMap, HashSet};
 use std::hash::Hash;
 
 #[inline]
-fn push_iter<L, V, I>(mut lua: L, iterator: I) -> PushGuard<L>
-    where L: AsMutLua,
+fn push_iter<'lua, L, V, I>(mut lua: L, iterator: I) -> PushGuard<L>
+    where L: AsMutLua<'lua>,
           V: for<'b> Push<&'b mut L>,
           I: Iterator<Item = V>
 {
@@ -32,15 +32,17 @@ fn push_iter<L, V, I>(mut lua: L, iterator: I) -> PushGuard<L>
         }
     }
 
+    let raw_lua = lua.as_lua();
     PushGuard {
         lua: lua,
         size: 1,
+        raw_lua: raw_lua,
     }
 }
 
 #[inline]
-fn push_rec_iter<L, V, I>(mut lua: L, iterator: I) -> PushGuard<L>
-    where L: AsMutLua,
+fn push_rec_iter<'lua, L, V, I>(mut lua: L, iterator: I) -> PushGuard<L>
+    where L: AsMutLua<'lua>,
           V: for<'a> Push<&'a mut L>,
           I: Iterator<Item = V>
 {
@@ -59,14 +61,16 @@ fn push_rec_iter<L, V, I>(mut lua: L, iterator: I) -> PushGuard<L>
         }
     }
 
+    let raw_lua = lua.as_lua();
     PushGuard {
         lua: lua,
         size: 1,
+        raw_lua: raw_lua,
     }
 }
 
-impl<L, T> Push<L> for Vec<T>
-    where L: AsMutLua,
+impl<'lua, L, T> Push<L> for Vec<T>
+    where L: AsMutLua<'lua>,
           T: for<'a> Push<&'a mut L>
 {
     #[inline]
@@ -75,8 +79,8 @@ impl<L, T> Push<L> for Vec<T>
     }
 }
 
-impl<'a, L, T> Push<L> for &'a [T]
-    where L: AsMutLua,
+impl<'a, 'lua, L, T> Push<L> for &'a [T]
+    where L: AsMutLua<'lua>,
           T: Clone + for<'b> Push<&'b mut L>
 {
     #[inline]
@@ -85,8 +89,8 @@ impl<'a, L, T> Push<L> for &'a [T]
     }
 }
 
-impl<L, K, V> Push<L> for HashMap<K, V>
-    where L: AsMutLua,
+impl<'lua, L, K, V> Push<L> for HashMap<K, V>
+    where L: AsMutLua<'lua>,
           K: for<'a, 'b> Push<&'a mut &'b mut L> + Eq + Hash,
           V: for<'a, 'b> Push<&'a mut &'b mut L>
 {
@@ -96,8 +100,8 @@ impl<L, K, V> Push<L> for HashMap<K, V>
     }
 }
 
-impl<L, K> Push<L> for HashSet<K>
-    where L: AsMutLua,
+impl<'lua, L, K> Push<L> for HashSet<K>
+    where L: AsMutLua<'lua>,
           K: for<'a, 'b> Push<&'a mut &'b mut L> + Eq + Hash
 {
     #[inline]

--- a/hlua/tests/userdata.rs
+++ b/hlua/tests/userdata.rs
@@ -4,15 +4,15 @@ extern crate hlua;
 fn readwrite() {
     #[derive(Clone)]
     struct Foo;
-    impl<L> hlua::Push<L> for Foo
-        where L: hlua::AsMutLua
+    impl<'lua, L> hlua::Push<L> for Foo
+        where L: hlua::AsMutLua<'lua>
     {
         fn push_to_lua(self, lua: L) -> hlua::PushGuard<L> {
             hlua::userdata::push_userdata(self, lua, |_| {})
         }
     }
-    impl<L> hlua::LuaRead<L> for Foo
-        where L: hlua::AsMutLua
+    impl<'lua, L> hlua::LuaRead<L> for Foo
+        where L: hlua::AsMutLua<'lua>
     {
         fn lua_read_at_position(lua: L, index: i32) -> Result<Foo, L> {
             let val: Result<hlua::userdata::UserdataOnStack<Foo, _>, _> =
@@ -44,8 +44,8 @@ fn destructor_called() {
         }
     }
 
-    impl<L> hlua::Push<L> for Foo
-        where L: hlua::AsMutLua
+    impl<'lua, L> hlua::Push<L> for Foo
+        where L: hlua::AsMutLua<'lua>
     {
         fn push_to_lua(self, lua: L) -> hlua::PushGuard<L> {
             hlua::userdata::push_userdata(self, lua, |_| {})
@@ -65,15 +65,15 @@ fn destructor_called() {
 fn type_check() {
     #[derive(Clone)]
     struct Foo;
-    impl<L> hlua::Push<L> for Foo
-        where L: hlua::AsMutLua
+    impl<'lua, L> hlua::Push<L> for Foo
+        where L: hlua::AsMutLua<'lua>
     {
         fn push_to_lua(self, lua: L) -> hlua::PushGuard<L> {
             hlua::userdata::push_userdata(self, lua, |_| {})
         }
     }
-    impl<L> hlua::LuaRead<L> for Foo
-        where L: hlua::AsMutLua
+    impl<'lua, L> hlua::LuaRead<L> for Foo
+        where L: hlua::AsMutLua<'lua>
     {
         fn lua_read_at_position(lua: L, index: i32) -> Result<Foo, L> {
             let val: Result<hlua::userdata::UserdataOnStack<Foo, _>, _> =
@@ -84,15 +84,15 @@ fn type_check() {
 
     #[derive(Clone)]
     struct Bar;
-    impl<L> hlua::Push<L> for Bar
-        where L: hlua::AsMutLua
+    impl<'lua, L> hlua::Push<L> for Bar
+        where L: hlua::AsMutLua<'lua>
     {
         fn push_to_lua(self, lua: L) -> hlua::PushGuard<L> {
             hlua::userdata::push_userdata(self, lua, |_| {})
         }
     }
-    impl<L> hlua::LuaRead<L> for Bar
-        where L: hlua::AsMutLua
+    impl<'lua, L> hlua::LuaRead<L> for Bar
+        where L: hlua::AsMutLua<'lua>
     {
         fn lua_read_at_position(lua: L, index: i32) -> Result<Bar, L> {
             let val: Result<hlua::userdata::UserdataOnStack<Bar, _>, _> =
@@ -113,8 +113,8 @@ fn type_check() {
 fn metatables() {
     #[derive(Clone)]
     struct Foo;
-    impl<L> hlua::Push<L> for Foo
-        where L: hlua::AsMutLua
+    impl<'lua, L> hlua::Push<L> for Foo
+        where L: hlua::AsMutLua<'lua>
     {
         fn push_to_lua(self, lua: L) -> hlua::PushGuard<L> {
             hlua::userdata::push_userdata(self, lua, |mut table| {


### PR DESCRIPTION
Fix #77 

I had to add a lifetime parameter to `AsLua` and `AsMutLua`.

Unfortunately since the `Drop` impl of `PushGuard` requires that the template parameter of `PushGuard` implements `AsMutLua`, that means I would have to add a lifetime parameter to the `PushGuard` struct as well. In order to avoid that, I added a `raw_lua` member instead. Same for `LuaTableIterator`.

Eventually this PR could be "reverted" (ie. `raw_lua` removed) and lifetime parameters of `AsLua` and `AsMutLua` could become associated lifetimes.
