### PR TITLE
Various optimizations

### DIFF
--- a/hlua/examples/basic.rs
+++ b/hlua/examples/basic.rs
@@ -1,0 +1,10 @@
+extern crate hlua;
+
+fn main() {
+    let mut lua = hlua::Lua::new();
+
+    lua.set("a", 12);
+    let val: i32 = lua.execute(r#"return a * 5;"#).unwrap();
+
+    assert_eq!(val, 60);
+}

--- a/hlua/src/functions_read.rs
+++ b/hlua/src/functions_read.rs
@@ -1,7 +1,6 @@
 use ffi;
 use libc;
 
-use std::ffi::CString;
 use std::io::Cursor;
 use std::io::Read;
 use std::io::Error as IoError;
@@ -106,11 +105,10 @@ impl<'lua, L> LuaFunction<L>
         };
 
         let (load_return_value, pushed_value) = unsafe {
-            let chunk_name = CString::new("chunk").unwrap();
             let code = ffi::lua_load(lua.as_mut_lua().0,
                                      reader::<R>,
                                      mem::transmute(&readdata),
-                                     chunk_name.as_ptr(),
+                                     b"chunk\0".as_ptr() as *const _,
                                      ptr::null());                         
             let raw_lua = lua.as_lua();
             (code,
@@ -148,8 +146,7 @@ impl<'lua, L> LuaFunction<L>
     /// Builds a new `LuaFunction` from a raw string.
     #[inline]
     pub fn load(lua: L, code: &str) -> Result<LuaFunction<PushGuard<L>>, LuaError> {
-        let code: Vec<_> = code.bytes().collect();
-        let reader = Cursor::new(code);
+        let reader = Cursor::new(code.as_bytes());
         LuaFunction::load_from_reader(lua, reader)
     }
 }

--- a/hlua/src/values.rs
+++ b/hlua/src/values.rs
@@ -1,4 +1,4 @@
-use std::ffi::{CStr, CString};
+use std::ffi::CStr;
 use std::mem;
 
 use ffi;
@@ -103,13 +103,16 @@ impl<'lua, L> Push<L> for String
 {
     #[inline]
     fn push_to_lua(self, mut lua: L) -> PushGuard<L> {
-        let value = CString::new(&self[..]).unwrap();
-        unsafe { ffi::lua_pushstring(lua.as_mut_lua().0, value.as_ptr()) };
-        let raw_lua = lua.as_lua();
-        PushGuard {
-            lua: lua,
-            size: 1,
-            raw_lua: raw_lua,
+        unsafe {
+            ffi::lua_pushlstring(lua.as_mut_lua().0, self.as_bytes().as_ptr() as *const _,
+                                 self.as_bytes().len() as libc::size_t);
+
+            let raw_lua = lua.as_lua();
+            PushGuard {
+                lua: lua,
+                size: 1,
+                raw_lua: raw_lua,
+            }
         }
     }
 }
@@ -137,13 +140,16 @@ impl<'lua, 's, L> Push<L> for &'s str
 {
     #[inline]
     fn push_to_lua(self, mut lua: L) -> PushGuard<L> {
-        let value = CString::new(&self[..]).unwrap();
-        unsafe { ffi::lua_pushstring(lua.as_mut_lua().0, value.as_ptr()) };
-        let raw_lua = lua.as_lua();
-        PushGuard {
-            lua: lua,
-            size: 1,
-            raw_lua: raw_lua,
+        unsafe {
+            ffi::lua_pushlstring(lua.as_mut_lua().0, self.as_bytes().as_ptr() as *const _,
+                                 self.as_bytes().len() as libc::size_t);
+
+            let raw_lua = lua.as_lua();
+            PushGuard {
+                lua: lua,
+                size: 1,
+                raw_lua: raw_lua,
+            }
         }
     }
 }


### PR DESCRIPTION
This PR greatly reduces the number of calls to `CString::new` and adds a basic example.

Running `cargo rustc --release --example basic -- --emit=asm` on this example now gives the following assembly (reorganized by me to follow jumps) which is very satisfying:

```asm
	movq	$-2, 496(%rbp)
	leaq	_ZN4hlua3Lua3new5alloc17h7ba710ca9ac163c0E(%rip), %rcx
	xorl	%edx, %edx
	callq	lua_newstate
	movq	%rax, %rbx
	testq	%rbx, %rbx
	je	.LBB9_1
	leaq	_ZN4hlua3Lua3new5panic17h36910d3e619d5a53E(%rip), %rdx
	movq	%rbx, %rcx
	callq	lua_atpanic
	movq	%rbx, 440(%rbp)
	movb	$1, 448(%rbp)
	movl	$-1001000, %edx
	movl	$2, %r8d
	movq	%rbx, %rcx
	callq	lua_rawgeti
	leaq	str.c(%rip), %rdx
	movl	$1, %r8d
	movq	%rbx, %rcx
	callq	lua_pushlstring
	movl	$12, %edx
	movq	%rbx, %rcx
	callq	lua_pushinteger
	movl	$-3, %edx
	movq	%rbx, %rcx
	callq	lua_settable
	movl	$-2, %edx
	movq	%rbx, %rcx
	callq	lua_settop
	leaq	str.d(%rip), %rax
	movq	%rax, -80(%rbp)
	movl	$13, %eax
	movd	%rax, %xmm0
	movups	%xmm0, -72(%rbp)
	movq	$0, 72(%rbp)
	movq	$0, 32(%rsp)
	leaq	_ZN4hlua14functions_read6reader17h7178b18bf4af289cE(%rip), %rdx
	leaq	byte_str.4(%rip), %r9
	leaq	-80(%rbp), %r8
	movq	%rbx, %rcx
	callq	lua_load
	movl	%eax, %r14d
	cmpq	$1, 72(%rbp)
	je	.LBB9_59
	testl	%r14d, %r14d
	je	.LBB9_61

.LBB9_61:
	movl	$-1, %edx
	movq	%rbx, %rcx
	callq	lua_pushvalue
	movq	$0, 40(%rsp)
	movl	$0, 32(%rsp)
	xorl	%edx, %edx
	movl	$1, %r8d
	xorl	%r9d, %r9d
	movq	%rbx, %rcx
	callq	lua_pcallk
	movl	%eax, 456(%rbp)
	testl	%eax, %eax
	je	.LBB9_106

.LBB9_106:
	leaq	-80(%rbp), %r8
	movl	$-1, %edx
	movq	%rbx, %rcx
	callq	lua_tointegerx
	movq	%rax, %rdi
	movl	-80(%rbp), %esi
	movl	$-2, %edx
	movq	%rbx, %rcx
	callq	lua_settop

... below is the `assert_eq!` ...
```