### PR TITLE
Allows pushing Lua code

### DIFF
--- a/hlua/src/any.rs
+++ b/hlua/src/any.rs
@@ -6,6 +6,7 @@ use AsMutLua;
 use Push;
 use PushGuard;
 use LuaRead;
+use Void;
 
 /// Represents any value that can be stored by Lua
 #[derive(Clone, Debug, PartialEq)]
@@ -24,10 +25,10 @@ pub enum AnyLuaValue {
 impl<'lua, L> Push<L> for AnyLuaValue
     where L: AsMutLua<'lua>
 {
-    type Err = ();      // TODO: use `!` instead (https://github.com/rust-lang/rust/issues/35121)
+    type Err = Void;      // TODO: use `!` instead (https://github.com/rust-lang/rust/issues/35121)
 
     #[inline]
-    fn push_to_lua(self, mut lua: L) -> Result<PushGuard<L>, ((), L)> {
+    fn push_to_lua(self, mut lua: L) -> Result<PushGuard<L>, (Void, L)> {
         let raw_lua = lua.as_lua();
         match self {
             AnyLuaValue::LuaString(val) => val.push_to_lua(lua),

--- a/hlua/src/any.rs
+++ b/hlua/src/any.rs
@@ -24,8 +24,10 @@ pub enum AnyLuaValue {
 impl<'lua, L> Push<L> for AnyLuaValue
     where L: AsMutLua<'lua>
 {
+    type Err = ();      // TODO: use `!` instead (https://github.com/rust-lang/rust/issues/35121)
+
     #[inline]
-    fn push_to_lua(self, mut lua: L) -> PushGuard<L> {
+    fn push_to_lua(self, mut lua: L) -> Result<PushGuard<L>, ((), L)> {
         let raw_lua = lua.as_lua();
         match self {
             AnyLuaValue::LuaString(val) => val.push_to_lua(lua),
@@ -36,11 +38,11 @@ impl<'lua, L> Push<L> for AnyLuaValue
                 unsafe {
                     ffi::lua_pushnil(lua.as_mut_lua().0);
                 }
-                PushGuard {
+                Ok(PushGuard {
                     lua: lua,
                     size: 1,
                     raw_lua: raw_lua,
-                }
+                })
             } // Use ffi::lua_pushnil.
             AnyLuaValue::LuaOther => panic!("can't push a AnyLuaValue of type Other"),
         }

--- a/hlua/src/functions_read.rs
+++ b/hlua/src/functions_read.rs
@@ -11,41 +11,105 @@ use AsMutLua;
 
 use LuaRead;
 use LuaError;
+use Push;
 use PushGuard;
+
+pub struct LuaCode<'a>(&'a str);
+
+impl<'lua, 'c, L> Push<L> for LuaCode<'c> where L: AsMutLua<'lua> {
+    #[inline]
+    fn push_to_lua(self, lua: L) -> PushGuard<L> {
+        LuaCodeFromReader(Cursor::new(self.0.as_bytes())).push_to_lua(lua)
+    }
+}
+
+pub struct LuaCodeFromReader<R>(R);
+
+impl<'lua, L, R> Push<L> for LuaCodeFromReader<R>
+    where L: AsMutLua<'lua>,
+          R: Read
+{
+    #[inline]
+    fn push_to_lua(self, mut lua: L) -> PushGuard<L> {
+        struct ReadData<R> {
+            reader: R,
+            buffer: [u8; 128],
+            triggered_error: Option<IoError>,
+        }
+
+        extern "C" fn reader<R>(_: *mut ffi::lua_State,
+                                data_raw: *mut libc::c_void,
+                                size: *mut libc::size_t)
+                                -> *const libc::c_char
+            where R: Read
+        {
+            let data: &mut ReadData<R> = unsafe { mem::transmute(data_raw) };
+
+            if data.triggered_error.is_some() {
+                unsafe { (*size) = 0 }
+                return data.buffer.as_ptr() as *const libc::c_char;
+            }
+
+            match data.reader.read(&mut data.buffer) {
+                Ok(len) => unsafe { (*size) = len as libc::size_t },
+                Err(e) => {
+                    unsafe { (*size) = 0 }
+                    data.triggered_error = Some(e)
+                }
+            };
+
+            data.buffer.as_ptr() as *const libc::c_char
+        }
+
+        let readdata = ReadData {
+            reader: self.0,
+            buffer: unsafe { ::std::mem::uninitialized() },
+            triggered_error: None,
+        };
+
+        let (load_return_value, pushed_value) = unsafe {
+            let code = ffi::lua_load(lua.as_mut_lua().0,
+                                     reader::<R>,
+                                     mem::transmute(&readdata),
+                                     b"chunk\0".as_ptr() as *const _,
+                                     ptr::null());                         
+            let raw_lua = lua.as_lua();
+            (code,
+             PushGuard {
+                 lua: lua,
+                 size: 1,
+                 raw_lua: raw_lua,
+             })
+        };
+
+        if readdata.triggered_error.is_some() {
+            let error = readdata.triggered_error.unwrap();
+            panic!()    // TODO: return Err(LuaError::ReadError(error));
+        }
+
+        if load_return_value == 0 {
+            return pushed_value;
+        }
+
+        let error_msg: String = LuaRead::lua_read(pushed_value)
+            .ok()
+            .expect("can't find error message at the top of the Lua stack");
+
+        if load_return_value == ffi::LUA_ERRMEM {
+            panic!("LUA_ERRMEM");
+        }
+
+        if load_return_value == ffi::LUA_ERRSYNTAX {
+            panic!() // TODO: return Err(LuaError::SyntaxError(error_msg));
+        }
+
+        panic!("Unknown error while calling lua_load");
+    }
+}
 
 ///
 pub struct LuaFunction<L> {
     variable: L,
-}
-
-struct ReadData<R> {
-    reader: R,
-    buffer: [u8; 128],
-    triggered_error: Option<IoError>,
-}
-
-extern "C" fn reader<R>(_: *mut ffi::lua_State,
-                        data_raw: *mut libc::c_void,
-                        size: *mut libc::size_t)
-                        -> *const libc::c_char
-    where R: Read
-{
-    let data: &mut ReadData<R> = unsafe { mem::transmute(data_raw) };
-
-    if data.triggered_error.is_some() {
-        unsafe { (*size) = 0 }
-        return data.buffer.as_ptr() as *const libc::c_char;
-    }
-
-    match data.reader.read(&mut data.buffer) {
-        Ok(len) => unsafe { (*size) = len as libc::size_t },
-        Err(e) => {
-            unsafe { (*size) = 0 }
-            data.triggered_error = Some(e)
-        }
-    };
-
-    data.buffer.as_ptr() as *const libc::c_char
 }
 
 impl<'lua, L> LuaFunction<L>
@@ -95,52 +159,11 @@ impl<'lua, L> LuaFunction<L>
 
     /// Builds a new `LuaFunction` from the code of a reader.
     #[inline]
-    pub fn load_from_reader<R>(mut lua: L, code: R) -> Result<LuaFunction<PushGuard<L>>, LuaError>
+    pub fn load_from_reader<R>(lua: L, code: R) -> Result<LuaFunction<PushGuard<L>>, LuaError>
         where R: Read
     {
-        let readdata = ReadData {
-            reader: code,
-            buffer: unsafe { ::std::mem::uninitialized() },
-            triggered_error: None,
-        };
-
-        let (load_return_value, pushed_value) = unsafe {
-            let code = ffi::lua_load(lua.as_mut_lua().0,
-                                     reader::<R>,
-                                     mem::transmute(&readdata),
-                                     b"chunk\0".as_ptr() as *const _,
-                                     ptr::null());                         
-            let raw_lua = lua.as_lua();
-            (code,
-             PushGuard {
-                 lua: lua,
-                 size: 1,
-                 raw_lua: raw_lua,
-             })
-        };
-
-        if readdata.triggered_error.is_some() {
-            let error = readdata.triggered_error.unwrap();
-            return Err(LuaError::ReadError(error));
-        }
-
-        if load_return_value == 0 {
-            return Ok(LuaFunction { variable: pushed_value });
-        }
-
-        let error_msg: String = LuaRead::lua_read(pushed_value)
-            .ok()
-            .expect("can't find error message at the top of the Lua stack");
-
-        if load_return_value == ffi::LUA_ERRMEM {
-            panic!("LUA_ERRMEM");
-        }
-
-        if load_return_value == ffi::LUA_ERRSYNTAX {
-            return Err(LuaError::SyntaxError(error_msg));
-        }
-
-        panic!("Unknown error while calling lua_load");
+        let pushed = LuaCodeFromReader(code).push_to_lua(lua);
+        Ok(LuaFunction { variable: pushed })
     }
 
     /// Builds a new `LuaFunction` from a raw string.

--- a/hlua/src/functions_write.rs
+++ b/hlua/src/functions_write.rs
@@ -70,8 +70,10 @@ macro_rules! impl_function_ext {
                       Z: 'lua + FnMut() -> R,
                       R: for<'a> Push<&'a mut InsideCallback> + 'static
         {
+            type Err = ();      // TODO: use `!` instead (https://github.com/rust-lang/rust/issues/35121)
+
             #[inline]
-            fn push_to_lua(self, mut lua: L) -> PushGuard<L> {
+            fn push_to_lua(self, mut lua: L) -> Result<PushGuard<L>, ((), L)> {
                 unsafe {
                     // pushing the function pointer as a userdata
                     let lua_data = ffi::lua_newuserdata(lua.as_mut_lua().0,
@@ -83,7 +85,7 @@ macro_rules! impl_function_ext {
                     let wrapper: extern fn(*mut ffi::lua_State) -> libc::c_int = wrapper::<Self, _, R>;
                     ffi::lua_pushcclosure(lua.as_mut_lua().0, wrapper, 1);
                     let raw_lua = lua.as_lua();
-                    PushGuard { lua: lua, size: 1, raw_lua: raw_lua }
+                    Ok(PushGuard { lua: lua, size: 1, raw_lua: raw_lua })
                 }
             }
         }
@@ -107,8 +109,10 @@ macro_rules! impl_function_ext {
                       ($($p,)*): for<'p> LuaRead<&'p mut InsideCallback>,
                       R: for<'a> Push<&'a mut InsideCallback> + 'static
         {
+            type Err = ();      // TODO: use `!` instead (https://github.com/rust-lang/rust/issues/35121)
+
             #[inline]
-            fn push_to_lua(self, mut lua: L) -> PushGuard<L> {
+            fn push_to_lua(self, mut lua: L) -> Result<PushGuard<L>, ((), L)> {
                 unsafe {
                     // pushing the function pointer as a userdata
                     let lua_data = ffi::lua_newuserdata(lua.as_mut_lua().0,
@@ -120,7 +124,7 @@ macro_rules! impl_function_ext {
                     let wrapper: extern fn(*mut ffi::lua_State) -> libc::c_int = wrapper::<Self, _, R>;
                     ffi::lua_pushcclosure(lua.as_mut_lua().0, wrapper, 1);
                     let raw_lua = lua.as_lua();
-                    PushGuard { lua: lua, size: 1, raw_lua: raw_lua }
+                    Ok(PushGuard { lua: lua, size: 1, raw_lua: raw_lua })
                 }
             }
         }
@@ -168,21 +172,26 @@ unsafe impl<'a, 'lua> AsMutLua<'lua> for &'a mut InsideCallback {
     }
 }
 
-impl<'a, T, E> Push<&'a mut InsideCallback> for Result<T, E>
-    where T: Push<&'a mut InsideCallback> + for<'b> Push<&'b mut &'a mut InsideCallback>,
+impl<'a, T, E, P> Push<&'a mut InsideCallback> for Result<T, E>
+    where T: Push<&'a mut InsideCallback, Err = P> + for<'b> Push<&'b mut &'a mut InsideCallback, Err = P>,
           E: Debug
 {
+    type Err = P;
+
     #[inline]
-    fn push_to_lua(self, mut lua: &'a mut InsideCallback) -> PushGuard<&'a mut InsideCallback> {
-        match self {
-            Ok(val) => val.push_to_lua(lua),
-            Err(val) => {
-                let msg = format!("{:?}", val);
-                msg.push_to_lua(&mut lua).forget();
-                unsafe {
+    fn push_to_lua(self, mut lua: &'a mut InsideCallback) -> Result<PushGuard<&'a mut InsideCallback>, (P, &'a mut InsideCallback)> {
+        unsafe {
+            match self {
+                Ok(val) => val.push_to_lua(lua),
+                Err(val) => {
+                    let msg = format!("{:?}", val);
+                    match msg.push_to_lua(&mut lua) {
+                        Ok(pushed) => pushed.forget(),
+                        Err(_) => unreachable!()
+                    };
                     ffi::lua_error(lua.as_mut_lua().0);
+                    unreachable!();
                 }
-                unreachable!();
             }
         }
     }
@@ -207,7 +216,10 @@ extern "C" fn wrapper<T, P, R>(lua: *mut ffi::lua_State) -> libc::c_int
     let args = match LuaRead::lua_read_at_position(&mut tmp_lua, -arguments_count as libc::c_int) {      // TODO: what if the user has the wrong params?
         Err(_) => {
             let err_msg = format!("wrong parameter types for callback function");
-            err_msg.push_to_lua(&mut tmp_lua).forget();
+            match err_msg.push_to_lua(&mut tmp_lua) {
+                Ok(p) => p.forget(),
+                Err(_) => unreachable!()
+            };
             unsafe {
                 ffi::lua_error(lua);
             }
@@ -219,6 +231,9 @@ extern "C" fn wrapper<T, P, R>(lua: *mut ffi::lua_State) -> libc::c_int
     let ret_value = data.call_mut(args);
 
     // pushing back the result of the function on the stack
-    let nb = ret_value.push_to_lua(&mut tmp_lua).forget();
+    let nb = match ret_value.push_to_lua(&mut tmp_lua) {
+        Ok(p) => p.forget(),
+        Err(_) => panic!()      // TODO: wrong
+    };
     nb as libc::c_int
 }

--- a/hlua/src/functions_write.rs
+++ b/hlua/src/functions_write.rs
@@ -7,6 +7,7 @@ use LuaContext;
 use LuaRead;
 use Push;
 use PushGuard;
+use Void;
 
 use std::marker::PhantomData;
 use std::fmt::Debug;
@@ -70,10 +71,10 @@ macro_rules! impl_function_ext {
                       Z: 'lua + FnMut() -> R,
                       R: for<'a> Push<&'a mut InsideCallback> + 'static
         {
-            type Err = ();      // TODO: use `!` instead (https://github.com/rust-lang/rust/issues/35121)
+            type Err = Void;      // TODO: use `!` instead (https://github.com/rust-lang/rust/issues/35121)
 
             #[inline]
-            fn push_to_lua(self, mut lua: L) -> Result<PushGuard<L>, ((), L)> {
+            fn push_to_lua(self, mut lua: L) -> Result<PushGuard<L>, (Void, L)> {
                 unsafe {
                     // pushing the function pointer as a userdata
                     let lua_data = ffi::lua_newuserdata(lua.as_mut_lua().0,
@@ -109,10 +110,10 @@ macro_rules! impl_function_ext {
                       ($($p,)*): for<'p> LuaRead<&'p mut InsideCallback>,
                       R: for<'a> Push<&'a mut InsideCallback> + 'static
         {
-            type Err = ();      // TODO: use `!` instead (https://github.com/rust-lang/rust/issues/35121)
+            type Err = Void;      // TODO: use `!` instead (https://github.com/rust-lang/rust/issues/35121)
 
             #[inline]
-            fn push_to_lua(self, mut lua: L) -> Result<PushGuard<L>, ((), L)> {
+            fn push_to_lua(self, mut lua: L) -> Result<PushGuard<L>, (Void, L)> {
                 unsafe {
                     // pushing the function pointer as a userdata
                     let lua_data = ffi::lua_newuserdata(lua.as_mut_lua().0,

--- a/hlua/src/lib.rs
+++ b/hlua/src/lib.rs
@@ -170,6 +170,12 @@ pub trait Push<L> {
     fn push_to_lua(self, lua: L) -> Result<PushGuard<L>, (Self::Err, L)>;
 }
 
+/// Type that cannot be instantiated.
+///
+/// Will be replaced with `!` eventually (https://github.com/rust-lang/rust/issues/35121).
+#[derive(Debug, Copy, Clone)]
+pub enum Void {}
+
 /// Types that can be obtained from a Lua context.
 ///
 /// Most types that implement `Push` also implement `LuaRead`, but this is not always the case

--- a/hlua/src/macros.rs
+++ b/hlua/src/macros.rs
@@ -2,9 +2,9 @@
 macro_rules! implement_lua_push {
     ($ty:ty, $cb:expr) => {
         impl<'lua, L> $crate::Push<L> for $ty where L: $crate::AsMutLua<'lua> {
-            type Err = ();      // TODO: use ! instead
+            type Err = $crate::Void;      // TODO: use ! instead
             #[inline]
-            fn push_to_lua(self, lua: L) -> Result<$crate::PushGuard<L>, ((), L)> {
+            fn push_to_lua(self, lua: L) -> Result<$crate::PushGuard<L>, ($crate::Void, L)> {
                 Ok($crate::userdata::push_userdata(self, lua, $cb))
             }
         }

--- a/hlua/src/macros.rs
+++ b/hlua/src/macros.rs
@@ -2,9 +2,10 @@
 macro_rules! implement_lua_push {
     ($ty:ty, $cb:expr) => {
         impl<'lua, L> $crate::Push<L> for $ty where L: $crate::AsMutLua<'lua> {
+            type Err = ();      // TODO: use ! instead
             #[inline]
-            fn push_to_lua(self, lua: L) -> $crate::PushGuard<L> {
-                $crate::userdata::push_userdata(self, lua, $cb)
+            fn push_to_lua(self, lua: L) -> Result<$crate::PushGuard<L>, ((), L)> {
+                Ok($crate::userdata::push_userdata(self, lua, $cb))
             }
         }
     };

--- a/hlua/src/rust_tables.rs
+++ b/hlua/src/rust_tables.rs
@@ -3,6 +3,7 @@ use ffi;
 use Push;
 use PushGuard;
 use AsMutLua;
+use Void;
 
 use std::collections::{HashMap, HashSet};
 use std::hash::Hash;
@@ -109,10 +110,10 @@ impl<'lua, L, K, V, E> Push<L> for HashMap<K, V>
           K: for<'a, 'b> Push<&'a mut &'b mut L, Err = E> + Eq + Hash,
           V: for<'a, 'b> Push<&'a mut &'b mut L, Err = E>
 {
-    type Err = ();      // TODO: can't use E because pushing tuples
+    type Err = Void;      // TODO: can't use E because pushing tuples
 
     #[inline]
-    fn push_to_lua(self, lua: L) -> Result<PushGuard<L>, ((), L)>  {
+    fn push_to_lua(self, lua: L) -> Result<PushGuard<L>, (Void, L)>  {
         push_rec_iter(lua, self.into_iter())
     }
 }
@@ -121,10 +122,10 @@ impl<'lua, L, K, E> Push<L> for HashSet<K>
     where L: AsMutLua<'lua>,
           K: for<'a, 'b> Push<&'a mut &'b mut L, Err = E> + Eq + Hash
 {
-    type Err = ();      // TODO: can't use E because pushing tuples
+    type Err = Void;      // TODO: can't use E because pushing tuples
 
     #[inline]
-    fn push_to_lua(self, lua: L) -> Result<PushGuard<L>, ((), L)> {
+    fn push_to_lua(self, lua: L) -> Result<PushGuard<L>, (Void, L)> {
         push_rec_iter(lua, self.into_iter().zip(iter::repeat(true)))
     }
 }

--- a/hlua/src/rust_tables.rs
+++ b/hlua/src/rust_tables.rs
@@ -6,24 +6,31 @@ use AsMutLua;
 
 use std::collections::{HashMap, HashSet};
 use std::hash::Hash;
+use std::iter;
 
 #[inline]
-fn push_iter<'lua, L, V, I>(mut lua: L, iterator: I) -> PushGuard<L>
+fn push_iter<'lua, L, V, I, E>(mut lua: L, iterator: I) -> Result<PushGuard<L>, (E, L)>
     where L: AsMutLua<'lua>,
-          V: for<'b> Push<&'b mut L>,
+          V: for<'b> Push<&'b mut L, Err = E>,
           I: Iterator<Item = V>
 {
     // creating empty table
     unsafe { ffi::lua_newtable(lua.as_mut_lua().0) };
 
     for (elem, index) in iterator.zip((1..)) {
-        let size = elem.push_to_lua(&mut lua).forget();
+        let size = match elem.push_to_lua(&mut lua) {
+            Ok(pushed) => pushed.forget(),
+            Err((err, lua)) => panic!(),     // TODO: wrong   return Err((err, lua)),      // FIXME: destroy the temporary table
+        };
 
         match size {
             0 => continue,
             1 => {
                 let index = index as u32;
-                index.push_to_lua(&mut lua).forget();
+                match index.push_to_lua(&mut lua) {
+                    Ok(pushed) => pushed.forget(),
+                    Err(_) => unreachable!()
+                };
                 unsafe { ffi::lua_insert(lua.as_mut_lua().0, -2) }
                 unsafe { ffi::lua_settable(lua.as_mut_lua().0, -3) }
             }
@@ -33,17 +40,17 @@ fn push_iter<'lua, L, V, I>(mut lua: L, iterator: I) -> PushGuard<L>
     }
 
     let raw_lua = lua.as_lua();
-    PushGuard {
+    Ok(PushGuard {
         lua: lua,
         size: 1,
         raw_lua: raw_lua,
-    }
+    })
 }
 
 #[inline]
-fn push_rec_iter<'lua, L, V, I>(mut lua: L, iterator: I) -> PushGuard<L>
+fn push_rec_iter<'lua, L, V, I, E>(mut lua: L, iterator: I) -> Result<PushGuard<L>, (E, L)>
     where L: AsMutLua<'lua>,
-          V: for<'a> Push<&'a mut L>,
+          V: for<'a> Push<&'a mut L, Err = E>,
           I: Iterator<Item = V>
 {
     let (nrec, _) = iterator.size_hint();
@@ -52,7 +59,10 @@ fn push_rec_iter<'lua, L, V, I>(mut lua: L, iterator: I) -> PushGuard<L>
     unsafe { ffi::lua_createtable(lua.as_mut_lua().0, 0, nrec as i32) };
 
     for elem in iterator {
-        let size = elem.push_to_lua(&mut lua).forget();
+        let size = match elem.push_to_lua(&mut lua) {
+            Ok(pushed) => pushed.forget(),
+            Err((err, lua)) => panic!()     // TODO: wrong   return Err((err, lua)),      // FIXME: destroy the temporary table
+        };
 
         match size {
             0 => continue,
@@ -62,51 +72,59 @@ fn push_rec_iter<'lua, L, V, I>(mut lua: L, iterator: I) -> PushGuard<L>
     }
 
     let raw_lua = lua.as_lua();
-    PushGuard {
+    Ok(PushGuard {
         lua: lua,
         size: 1,
         raw_lua: raw_lua,
-    }
+    })
 }
 
-impl<'lua, L, T> Push<L> for Vec<T>
+impl<'lua, L, T, E> Push<L> for Vec<T>
     where L: AsMutLua<'lua>,
-          T: for<'a> Push<&'a mut L>
+          T: for<'a> Push<&'a mut L, Err = E>
 {
+    type Err = E;
+
     #[inline]
-    fn push_to_lua(self, lua: L) -> PushGuard<L> {
+    fn push_to_lua(self, lua: L) -> Result<PushGuard<L>, (E, L)>  {
         push_iter(lua, self.into_iter())
     }
 }
 
-impl<'a, 'lua, L, T> Push<L> for &'a [T]
+impl<'a, 'lua, L, T, E> Push<L> for &'a [T]
     where L: AsMutLua<'lua>,
-          T: Clone + for<'b> Push<&'b mut L>
+          T: Clone + for<'b> Push<&'b mut L, Err = E>
 {
+    type Err = E;
+
     #[inline]
-    fn push_to_lua(self, lua: L) -> PushGuard<L> {
+    fn push_to_lua(self, lua: L) -> Result<PushGuard<L>, (E, L)>  {
         push_iter(lua, self.iter().map(|e| e.clone()))
     }
 }
 
-impl<'lua, L, K, V> Push<L> for HashMap<K, V>
+// TODO: use an enum for the error to allow different error types for K and V
+impl<'lua, L, K, V, E> Push<L> for HashMap<K, V>
     where L: AsMutLua<'lua>,
-          K: for<'a, 'b> Push<&'a mut &'b mut L> + Eq + Hash,
-          V: for<'a, 'b> Push<&'a mut &'b mut L>
+          K: for<'a, 'b> Push<&'a mut &'b mut L, Err = E> + Eq + Hash,
+          V: for<'a, 'b> Push<&'a mut &'b mut L, Err = E>
 {
+    type Err = ();      // TODO: can't use E because pushing tuples
+
     #[inline]
-    fn push_to_lua(self, lua: L) -> PushGuard<L> {
+    fn push_to_lua(self, lua: L) -> Result<PushGuard<L>, ((), L)>  {
         push_rec_iter(lua, self.into_iter())
     }
 }
 
-impl<'lua, L, K> Push<L> for HashSet<K>
+impl<'lua, L, K, E> Push<L> for HashSet<K>
     where L: AsMutLua<'lua>,
-          K: for<'a, 'b> Push<&'a mut &'b mut L> + Eq + Hash
+          K: for<'a, 'b> Push<&'a mut &'b mut L, Err = E> + Eq + Hash
 {
+    type Err = ();      // TODO: can't use E because pushing tuples
+
     #[inline]
-    fn push_to_lua(self, lua: L) -> PushGuard<L> {
-        use std::iter;
+    fn push_to_lua(self, lua: L) -> Result<PushGuard<L>, ((), L)> {
         push_rec_iter(lua, self.into_iter().zip(iter::repeat(true)))
     }
 }

--- a/hlua/src/tuples.rs
+++ b/hlua/src/tuples.rs
@@ -4,6 +4,7 @@ use AsLua;
 use Push;
 use PushGuard;
 use LuaRead;
+use Void;
 
 macro_rules! tuple_impl {
     ($ty:ident) => (
@@ -29,7 +30,7 @@ macro_rules! tuple_impl {
         impl<'lua, LU, $first: for<'a> Push<&'a mut LU>, $($other: for<'a> Push<&'a mut LU>),+>
             Push<LU> for ($first, $($other),+) where LU: AsMutLua<'lua>
         {
-            type Err = ();      // TODO: wrong
+            type Err = Void;      // TODO: wrong
 
             #[inline]
             fn push_to_lua(self, mut lua: LU) -> Result<PushGuard<LU>, (Self::Err, LU)> {

--- a/hlua/src/tuples.rs
+++ b/hlua/src/tuples.rs
@@ -8,8 +8,10 @@ use LuaRead;
 macro_rules! tuple_impl {
     ($ty:ident) => (
         impl<'lua, LU, $ty> Push<LU> for ($ty,) where LU: AsMutLua<'lua>, $ty: Push<LU> {
+            type Err = <$ty as Push<LU>>::Err;
+
             #[inline]
-            fn push_to_lua(self, lua: LU) -> PushGuard<LU> {
+            fn push_to_lua(self, lua: LU) -> Result<PushGuard<LU>, (Self::Err, LU)> {
                 self.0.push_to_lua(lua)
             }
         }
@@ -27,18 +29,26 @@ macro_rules! tuple_impl {
         impl<'lua, LU, $first: for<'a> Push<&'a mut LU>, $($other: for<'a> Push<&'a mut LU>),+>
             Push<LU> for ($first, $($other),+) where LU: AsMutLua<'lua>
         {
+            type Err = ();      // TODO: wrong
+
             #[inline]
-            fn push_to_lua(self, mut lua: LU) -> PushGuard<LU> {
+            fn push_to_lua(self, mut lua: LU) -> Result<PushGuard<LU>, (Self::Err, LU)> {
                 match self {
                     ($first, $($other),+) => {
-                        let mut total = $first.push_to_lua(&mut lua).forget();
+                        let mut total = match $first.push_to_lua(&mut lua) {
+                            Ok(pushed) => pushed.forget(),
+                            Err(_) => panic!()      // TODO: wrong
+                        };
 
                         $(
-                            total += $other.push_to_lua(&mut lua).forget();
+                            total += match $other.push_to_lua(&mut lua) {
+                                Ok(pushed) => pushed.forget(),
+                                Err(_) => panic!()      // TODO: wrong
+                            };
                         )+
 
                         let raw_lua = lua.as_lua();
-                        PushGuard { lua: lua, size: total, raw_lua: raw_lua }
+                        Ok(PushGuard { lua: lua, size: total, raw_lua: raw_lua })
                     }
                 }
             }

--- a/hlua/src/userdata.rs
+++ b/hlua/src/userdata.rs
@@ -68,13 +68,22 @@ pub fn push_userdata<'lua, L, T, F>(data: T, mut lua: L, mut metatable: F) -> Pu
         ffi::lua_newtable(lua.as_mut_lua().0);
 
         // index "__typeid" corresponds to the hash of the TypeId of T
-        "__typeid".push_to_lua(&mut lua).forget();
-        typeid.push_to_lua(&mut lua).forget();
+        match "__typeid".push_to_lua(&mut lua) {
+            Ok(p) => p.forget(),
+            Err(_) => unreachable!()
+        };
+        match typeid.push_to_lua(&mut lua) {
+            Ok(p) => p.forget(),
+            Err(_) => unreachable!()
+        };
         ffi::lua_settable(lua.as_mut_lua().0, -3);
 
         // index "__gc" call the object's destructor
         {
-            "__gc".push_to_lua(&mut lua).forget();
+            match "__gc".push_to_lua(&mut lua) {
+                Ok(p) => p.forget(),
+                Err(_) => unreachable!()
+            };
 
             // pushing destructor_impl as a lightuserdata
             let destructor_impl: fn(*mut ffi::lua_State) -> libc::c_int = destructor_impl::<T>;
@@ -128,7 +137,10 @@ pub fn read_userdata<'t, 'c, T>(mut lua: &'c mut InsideCallback,
             return Err(lua);
         }
 
-        "__typeid".push_to_lua(&mut lua).forget();
+        match "__typeid".push_to_lua(&mut lua) {
+            Ok(p) => p.forget(),
+            Err(_) => unreachable!()
+        };
         ffi::lua_gettable(lua.as_lua().0, -2);
         match <String as LuaRead<_>>::lua_read(&mut lua) {
             Ok(ref val) if val == &expected_typeid => {}
@@ -166,7 +178,10 @@ impl<'lua, T, L> LuaRead<L> for UserdataOnStack<T, L>
                 return Err(lua);
             }
 
-            "__typeid".push_to_lua(&mut lua).forget();
+            match "__typeid".push_to_lua(&mut lua) {
+                Ok(p) => p.forget(),
+                Err(_) => unreachable!()
+            };
             ffi::lua_gettable(lua.as_lua().0, -2);
             match <String as LuaRead<_>>::lua_read(&mut lua) {
                 Ok(ref val) if val == &expected_typeid => {}

--- a/hlua/src/values.rs
+++ b/hlua/src/values.rs
@@ -9,14 +9,15 @@ use AsMutLua;
 use LuaRead;
 use Push;
 use PushGuard;
+use Void;
 
 macro_rules! integer_impl(
     ($t:ident) => (
         impl<'lua, L> Push<L> for $t where L: AsMutLua<'lua> {
-            type Err = ();      // TODO: use `!` instead (https://github.com/rust-lang/rust/issues/35121)
+            type Err = Void;      // TODO: use `!` instead (https://github.com/rust-lang/rust/issues/35121)
 
             #[inline]
-            fn push_to_lua(self, mut lua: L) -> Result<PushGuard<L>, ((), L)> {
+            fn push_to_lua(self, mut lua: L) -> Result<PushGuard<L>, (Void, L)> {
                 unsafe { ffi::lua_pushinteger(lua.as_mut_lua().0, self as ffi::lua_Integer) };
                 let raw_lua = lua.as_lua();
                 Ok(PushGuard { lua: lua, size: 1, raw_lua: raw_lua })
@@ -45,10 +46,10 @@ integer_impl!(i32);
 macro_rules! unsigned_impl(
     ($t:ident) => (
         impl<'lua, L> Push<L> for $t where L: AsMutLua<'lua> {
-            type Err = ();      // TODO: use `!` instead (https://github.com/rust-lang/rust/issues/35121)
+            type Err = Void;      // TODO: use `!` instead (https://github.com/rust-lang/rust/issues/35121)
 
             #[inline]
-            fn push_to_lua(self, mut lua: L) -> Result<PushGuard<L>, ((), L)> {
+            fn push_to_lua(self, mut lua: L) -> Result<PushGuard<L>, (Void, L)> {
                 unsafe { ffi::lua_pushunsigned(lua.as_mut_lua().0, self as ffi::lua_Unsigned) };
                 let raw_lua = lua.as_lua();
                 Ok(PushGuard { lua: lua, size: 1, raw_lua: raw_lua })
@@ -77,10 +78,10 @@ unsigned_impl!(u32);
 macro_rules! numeric_impl(
     ($t:ident) => (
         impl<'lua, L> Push<L> for $t where L: AsMutLua<'lua> {
-            type Err = ();      // TODO: use `!` instead (https://github.com/rust-lang/rust/issues/35121)
+            type Err = Void;      // TODO: use `!` instead (https://github.com/rust-lang/rust/issues/35121)
 
             #[inline]
-            fn push_to_lua(self, mut lua: L) -> Result<PushGuard<L>, ((), L)> {
+            fn push_to_lua(self, mut lua: L) -> Result<PushGuard<L>, (Void, L)> {
                 unsafe { ffi::lua_pushnumber(lua.as_mut_lua().0, self as f64) };
                 let raw_lua = lua.as_lua();
                 Ok(PushGuard { lua: lua, size: 1, raw_lua: raw_lua })
@@ -107,10 +108,10 @@ numeric_impl!(f64);
 impl<'lua, L> Push<L> for String
     where L: AsMutLua<'lua>
 {
-    type Err = ();      // TODO: use `!` instead (https://github.com/rust-lang/rust/issues/35121)
+    type Err = Void;      // TODO: use `!` instead (https://github.com/rust-lang/rust/issues/35121)
 
     #[inline]
-    fn push_to_lua(self, mut lua: L) -> Result<PushGuard<L>, ((), L)> {
+    fn push_to_lua(self, mut lua: L) -> Result<PushGuard<L>, (Void, L)> {
         unsafe {
             ffi::lua_pushlstring(lua.as_mut_lua().0, self.as_bytes().as_ptr() as *const _,
                                  self.as_bytes().len() as libc::size_t);
@@ -146,10 +147,10 @@ impl<'lua, L> LuaRead<L> for String
 impl<'lua, 's, L> Push<L> for &'s str
     where L: AsMutLua<'lua>
 {
-    type Err = ();      // TODO: use `!` instead (https://github.com/rust-lang/rust/issues/35121)
+    type Err = Void;      // TODO: use `!` instead (https://github.com/rust-lang/rust/issues/35121)
 
     #[inline]
-    fn push_to_lua(self, mut lua: L) -> Result<PushGuard<L>, ((), L)> {
+    fn push_to_lua(self, mut lua: L) -> Result<PushGuard<L>, (Void, L)> {
         unsafe {
             ffi::lua_pushlstring(lua.as_mut_lua().0, self.as_bytes().as_ptr() as *const _,
                                  self.as_bytes().len() as libc::size_t);
@@ -167,10 +168,10 @@ impl<'lua, 's, L> Push<L> for &'s str
 impl<'lua, L> Push<L> for bool
     where L: AsMutLua<'lua>
 {
-    type Err = ();      // TODO: use `!` instead (https://github.com/rust-lang/rust/issues/35121)
+    type Err = Void;      // TODO: use `!` instead (https://github.com/rust-lang/rust/issues/35121)
 
     #[inline]
-    fn push_to_lua(self, mut lua: L) -> Result<PushGuard<L>, ((), L)> {
+    fn push_to_lua(self, mut lua: L) -> Result<PushGuard<L>, (Void, L)> {
         unsafe { ffi::lua_pushboolean(lua.as_mut_lua().0, self.clone() as libc::c_int) };
         let raw_lua = lua.as_lua();
         Ok(PushGuard {
@@ -197,10 +198,10 @@ impl<'lua, L> LuaRead<L> for bool
 impl<'lua, L> Push<L> for ()
     where L: AsMutLua<'lua>
 {
-    type Err = ();      // TODO: use `!` instead (https://github.com/rust-lang/rust/issues/35121)
+    type Err = Void;      // TODO: use `!` instead (https://github.com/rust-lang/rust/issues/35121)
 
     #[inline]
-    fn push_to_lua(self, lua: L) -> Result<PushGuard<L>, ((), L)> {
+    fn push_to_lua(self, lua: L) -> Result<PushGuard<L>, (Void, L)> {
         let raw_lua = lua.as_lua();
 
         Ok(PushGuard {

--- a/hlua/src/values.rs
+++ b/hlua/src/values.rs
@@ -13,11 +13,13 @@ use PushGuard;
 macro_rules! integer_impl(
     ($t:ident) => (
         impl<'lua, L> Push<L> for $t where L: AsMutLua<'lua> {
+            type Err = ();      // TODO: use `!` instead (https://github.com/rust-lang/rust/issues/35121)
+
             #[inline]
-            fn push_to_lua(self, mut lua: L) -> PushGuard<L> {
+            fn push_to_lua(self, mut lua: L) -> Result<PushGuard<L>, ((), L)> {
                 unsafe { ffi::lua_pushinteger(lua.as_mut_lua().0, self as ffi::lua_Integer) };
                 let raw_lua = lua.as_lua();
-                PushGuard { lua: lua, size: 1, raw_lua: raw_lua }
+                Ok(PushGuard { lua: lua, size: 1, raw_lua: raw_lua })
             }
         }
 
@@ -43,11 +45,13 @@ integer_impl!(i32);
 macro_rules! unsigned_impl(
     ($t:ident) => (
         impl<'lua, L> Push<L> for $t where L: AsMutLua<'lua> {
+            type Err = ();      // TODO: use `!` instead (https://github.com/rust-lang/rust/issues/35121)
+
             #[inline]
-            fn push_to_lua(self, mut lua: L) -> PushGuard<L> {
+            fn push_to_lua(self, mut lua: L) -> Result<PushGuard<L>, ((), L)> {
                 unsafe { ffi::lua_pushunsigned(lua.as_mut_lua().0, self as ffi::lua_Unsigned) };
                 let raw_lua = lua.as_lua();
-                PushGuard { lua: lua, size: 1, raw_lua: raw_lua }
+                Ok(PushGuard { lua: lua, size: 1, raw_lua: raw_lua })
             }
         }
 
@@ -73,11 +77,13 @@ unsigned_impl!(u32);
 macro_rules! numeric_impl(
     ($t:ident) => (
         impl<'lua, L> Push<L> for $t where L: AsMutLua<'lua> {
+            type Err = ();      // TODO: use `!` instead (https://github.com/rust-lang/rust/issues/35121)
+
             #[inline]
-            fn push_to_lua(self, mut lua: L) -> PushGuard<L> {
+            fn push_to_lua(self, mut lua: L) -> Result<PushGuard<L>, ((), L)> {
                 unsafe { ffi::lua_pushnumber(lua.as_mut_lua().0, self as f64) };
                 let raw_lua = lua.as_lua();
-                PushGuard { lua: lua, size: 1, raw_lua: raw_lua }
+                Ok(PushGuard { lua: lua, size: 1, raw_lua: raw_lua })
             }
         }
 
@@ -101,18 +107,20 @@ numeric_impl!(f64);
 impl<'lua, L> Push<L> for String
     where L: AsMutLua<'lua>
 {
+    type Err = ();      // TODO: use `!` instead (https://github.com/rust-lang/rust/issues/35121)
+
     #[inline]
-    fn push_to_lua(self, mut lua: L) -> PushGuard<L> {
+    fn push_to_lua(self, mut lua: L) -> Result<PushGuard<L>, ((), L)> {
         unsafe {
             ffi::lua_pushlstring(lua.as_mut_lua().0, self.as_bytes().as_ptr() as *const _,
                                  self.as_bytes().len() as libc::size_t);
 
             let raw_lua = lua.as_lua();
-            PushGuard {
+            Ok(PushGuard {
                 lua: lua,
                 size: 1,
                 raw_lua: raw_lua,
-            }
+            })
         }
     }
 }
@@ -138,18 +146,20 @@ impl<'lua, L> LuaRead<L> for String
 impl<'lua, 's, L> Push<L> for &'s str
     where L: AsMutLua<'lua>
 {
+    type Err = ();      // TODO: use `!` instead (https://github.com/rust-lang/rust/issues/35121)
+
     #[inline]
-    fn push_to_lua(self, mut lua: L) -> PushGuard<L> {
+    fn push_to_lua(self, mut lua: L) -> Result<PushGuard<L>, ((), L)> {
         unsafe {
             ffi::lua_pushlstring(lua.as_mut_lua().0, self.as_bytes().as_ptr() as *const _,
                                  self.as_bytes().len() as libc::size_t);
 
             let raw_lua = lua.as_lua();
-            PushGuard {
+            Ok(PushGuard {
                 lua: lua,
                 size: 1,
                 raw_lua: raw_lua,
-            }
+            })
         }
     }
 }
@@ -157,15 +167,17 @@ impl<'lua, 's, L> Push<L> for &'s str
 impl<'lua, L> Push<L> for bool
     where L: AsMutLua<'lua>
 {
+    type Err = ();      // TODO: use `!` instead (https://github.com/rust-lang/rust/issues/35121)
+
     #[inline]
-    fn push_to_lua(self, mut lua: L) -> PushGuard<L> {
+    fn push_to_lua(self, mut lua: L) -> Result<PushGuard<L>, ((), L)> {
         unsafe { ffi::lua_pushboolean(lua.as_mut_lua().0, self.clone() as libc::c_int) };
         let raw_lua = lua.as_lua();
-        PushGuard {
+        Ok(PushGuard {
             lua: lua,
             size: 1,
             raw_lua: raw_lua,
-        }
+        })
     }
 }
 
@@ -185,15 +197,17 @@ impl<'lua, L> LuaRead<L> for bool
 impl<'lua, L> Push<L> for ()
     where L: AsMutLua<'lua>
 {
+    type Err = ();      // TODO: use `!` instead (https://github.com/rust-lang/rust/issues/35121)
+
     #[inline]
-    fn push_to_lua(self, lua: L) -> PushGuard<L> {
+    fn push_to_lua(self, lua: L) -> Result<PushGuard<L>, ((), L)> {
         let raw_lua = lua.as_lua();
 
-        PushGuard {
+        Ok(PushGuard {
             lua: lua,
             size: 0,
             raw_lua: raw_lua,
-        }
+        })
     }
 }
 

--- a/hlua/tests/userdata.rs
+++ b/hlua/tests/userdata.rs
@@ -7,8 +7,9 @@ fn readwrite() {
     impl<'lua, L> hlua::Push<L> for Foo
         where L: hlua::AsMutLua<'lua>
     {
-        fn push_to_lua(self, lua: L) -> hlua::PushGuard<L> {
-            hlua::userdata::push_userdata(self, lua, |_| {})
+        type Err = ();
+        fn push_to_lua(self, lua: L) -> Result<hlua::PushGuard<L>, ((), L)> {
+            Ok(hlua::userdata::push_userdata(self, lua, |_| {}))
         }
     }
     impl<'lua, L> hlua::LuaRead<L> for Foo
@@ -47,8 +48,9 @@ fn destructor_called() {
     impl<'lua, L> hlua::Push<L> for Foo
         where L: hlua::AsMutLua<'lua>
     {
-        fn push_to_lua(self, lua: L) -> hlua::PushGuard<L> {
-            hlua::userdata::push_userdata(self, lua, |_| {})
+        type Err = ();
+        fn push_to_lua(self, lua: L) -> Result<hlua::PushGuard<L>, ((), L)> {
+            Ok(hlua::userdata::push_userdata(self, lua, |_| {}))
         }
     }
 
@@ -68,8 +70,9 @@ fn type_check() {
     impl<'lua, L> hlua::Push<L> for Foo
         where L: hlua::AsMutLua<'lua>
     {
-        fn push_to_lua(self, lua: L) -> hlua::PushGuard<L> {
-            hlua::userdata::push_userdata(self, lua, |_| {})
+        type Err = ();
+        fn push_to_lua(self, lua: L) -> Result<hlua::PushGuard<L>, ((), L)> {
+            Ok(hlua::userdata::push_userdata(self, lua, |_| {}))
         }
     }
     impl<'lua, L> hlua::LuaRead<L> for Foo
@@ -87,8 +90,9 @@ fn type_check() {
     impl<'lua, L> hlua::Push<L> for Bar
         where L: hlua::AsMutLua<'lua>
     {
-        fn push_to_lua(self, lua: L) -> hlua::PushGuard<L> {
-            hlua::userdata::push_userdata(self, lua, |_| {})
+        type Err = ();
+        fn push_to_lua(self, lua: L) -> Result<hlua::PushGuard<L>, ((), L)> {
+            Ok(hlua::userdata::push_userdata(self, lua, |_| {}))
         }
     }
     impl<'lua, L> hlua::LuaRead<L> for Bar
@@ -116,11 +120,12 @@ fn metatables() {
     impl<'lua, L> hlua::Push<L> for Foo
         where L: hlua::AsMutLua<'lua>
     {
-        fn push_to_lua(self, lua: L) -> hlua::PushGuard<L> {
-            hlua::userdata::push_userdata(self, lua, |mut table| {
+        type Err = ();
+        fn push_to_lua(self, lua: L) -> Result<hlua::PushGuard<L>, ((), L)> {
+            Ok(hlua::userdata::push_userdata(self, lua, |mut table| {
                 table.set("__index".to_string(),
                           vec![("test".to_string(), hlua::function0(|| 5))]);
-            })
+            }))
         }
     }
 

--- a/hlua/tests/userdata.rs
+++ b/hlua/tests/userdata.rs
@@ -7,8 +7,8 @@ fn readwrite() {
     impl<'lua, L> hlua::Push<L> for Foo
         where L: hlua::AsMutLua<'lua>
     {
-        type Err = ();
-        fn push_to_lua(self, lua: L) -> Result<hlua::PushGuard<L>, ((), L)> {
+        type Err = hlua::Void;
+        fn push_to_lua(self, lua: L) -> Result<hlua::PushGuard<L>, (hlua::Void, L)> {
             Ok(hlua::userdata::push_userdata(self, lua, |_| {}))
         }
     }
@@ -48,8 +48,8 @@ fn destructor_called() {
     impl<'lua, L> hlua::Push<L> for Foo
         where L: hlua::AsMutLua<'lua>
     {
-        type Err = ();
-        fn push_to_lua(self, lua: L) -> Result<hlua::PushGuard<L>, ((), L)> {
+        type Err = hlua::Void;
+        fn push_to_lua(self, lua: L) -> Result<hlua::PushGuard<L>, (hlua::Void, L)> {
             Ok(hlua::userdata::push_userdata(self, lua, |_| {}))
         }
     }
@@ -70,8 +70,8 @@ fn type_check() {
     impl<'lua, L> hlua::Push<L> for Foo
         where L: hlua::AsMutLua<'lua>
     {
-        type Err = ();
-        fn push_to_lua(self, lua: L) -> Result<hlua::PushGuard<L>, ((), L)> {
+        type Err = hlua::Void;
+        fn push_to_lua(self, lua: L) -> Result<hlua::PushGuard<L>, (hlua::Void, L)> {
             Ok(hlua::userdata::push_userdata(self, lua, |_| {}))
         }
     }
@@ -90,8 +90,8 @@ fn type_check() {
     impl<'lua, L> hlua::Push<L> for Bar
         where L: hlua::AsMutLua<'lua>
     {
-        type Err = ();
-        fn push_to_lua(self, lua: L) -> Result<hlua::PushGuard<L>, ((), L)> {
+        type Err = hlua::Void;
+        fn push_to_lua(self, lua: L) -> Result<hlua::PushGuard<L>, (hlua::Void, L)> {
             Ok(hlua::userdata::push_userdata(self, lua, |_| {}))
         }
     }
@@ -120,8 +120,8 @@ fn metatables() {
     impl<'lua, L> hlua::Push<L> for Foo
         where L: hlua::AsMutLua<'lua>
     {
-        type Err = ();
-        fn push_to_lua(self, lua: L) -> Result<hlua::PushGuard<L>, ((), L)> {
+        type Err = hlua::Void;
+        fn push_to_lua(self, lua: L) -> Result<hlua::PushGuard<L>, (hlua::Void, L)> {
             Ok(hlua::userdata::push_userdata(self, lua, |mut table| {
                 table.set("__index".to_string(),
                           vec![("test".to_string(), hlua::function0(|| 5))]);


### PR DESCRIPTION
This PR allows pushing Lua code.

For example:
```
lua.set("foo", hlua::functions_read::LuaCode("return 5"));
```

You can then do:

```rust
let r = lua.execute_code::<i32>("foo()").unwrap();
assert_eq!(r, 5);
```

Similar to `LuaCode`, also adds `LuaCodeFromReader`.

This change required modifying the `Push` trait to return a `Result` instead, in order to handle syntax errors.
More code cleanups will need to be made later. Since the code was quite dirty already, I don't think it's a problem to add even more panicking corner cases.
