### PR TITLE
Hide all modules and reexports types in global scope

### DIFF
--- a/hlua/src/lib.rs
+++ b/hlua/src/lib.rs
@@ -7,22 +7,26 @@ use std::io::Error as IoError;
 use std::borrow::Borrow;
 use std::marker::PhantomData;
 
+pub use any::AnyLuaValue;
 pub use functions_read::LuaFunction;
+pub use functions_read::{LuaCode, LuaCodeFromReader};
 pub use functions_write::{Function, InsideCallback};
 pub use functions_write::{function0, function1, function2, function3, function4, function5};
 pub use functions_write::{function6, function7, function8, function9, function10};
 pub use lua_tables::LuaTable;
-pub mod any;
-pub mod functions_read;
-pub mod lua_tables;
-pub mod userdata;
+pub use lua_tables::LuaTableIterator;
+pub use userdata::UserdataOnStack;
+pub use userdata::{push_userdata, read_userdata};
 
+mod any;
+mod functions_read;
 mod functions_write;
+mod lua_tables;
 mod macros;
 mod rust_tables;
+mod userdata;
 mod values;
 mod tuples;
-
 
 /// Main object of the library.
 ///
@@ -561,7 +565,7 @@ impl<'lua> Lua<'lua> {
     ///
     /// ```
     /// use hlua::Lua;
-    /// use hlua::any::AnyLuaValue;
+    /// use hlua::AnyLuaValue;
     ///
     /// let mut lua = Lua::new();
     /// {

--- a/hlua/src/macros.rs
+++ b/hlua/src/macros.rs
@@ -5,7 +5,7 @@ macro_rules! implement_lua_push {
             type Err = $crate::Void;      // TODO: use ! instead
             #[inline]
             fn push_to_lua(self, lua: L) -> Result<$crate::PushGuard<L>, ($crate::Void, L)> {
-                Ok($crate::userdata::push_userdata(self, lua, $cb))
+                Ok($crate::push_userdata(self, lua, $cb))
             }
         }
     };
@@ -18,7 +18,7 @@ macro_rules! implement_lua_read {
             #[inline]
             fn lua_read_at_position(lua: &'c mut hlua::InsideCallback, index: i32) -> Result<&'s mut $ty, &'c mut hlua::InsideCallback> {
                 // FIXME:
-                unsafe { ::std::mem::transmute($crate::userdata::read_userdata::<$ty>(lua, index)) }
+                unsafe { ::std::mem::transmute($crate::read_userdata::<$ty>(lua, index)) }
             }
         }
 
@@ -26,7 +26,7 @@ macro_rules! implement_lua_read {
             #[inline]
             fn lua_read_at_position(lua: &'c mut hlua::InsideCallback, index: i32) -> Result<&'s $ty, &'c mut hlua::InsideCallback> {
                 // FIXME:
-                unsafe { ::std::mem::transmute($crate::userdata::read_userdata::<$ty>(lua, index)) }
+                unsafe { ::std::mem::transmute($crate::read_userdata::<$ty>(lua, index)) }
             }
         }
 

--- a/hlua/tests/anyvalue.rs
+++ b/hlua/tests/anyvalue.rs
@@ -1,7 +1,7 @@
 extern crate hlua;
 
 use hlua::Lua;
-use hlua::any::AnyLuaValue;
+use hlua::AnyLuaValue;
 
 #[test]
 fn read_numbers() {

--- a/hlua/tests/userdata.rs
+++ b/hlua/tests/userdata.rs
@@ -9,14 +9,14 @@ fn readwrite() {
     {
         type Err = hlua::Void;
         fn push_to_lua(self, lua: L) -> Result<hlua::PushGuard<L>, (hlua::Void, L)> {
-            Ok(hlua::userdata::push_userdata(self, lua, |_| {}))
+            Ok(hlua::push_userdata(self, lua, |_| {}))
         }
     }
     impl<'lua, L> hlua::LuaRead<L> for Foo
         where L: hlua::AsMutLua<'lua>
     {
         fn lua_read_at_position(lua: L, index: i32) -> Result<Foo, L> {
-            let val: Result<hlua::userdata::UserdataOnStack<Foo, _>, _> =
+            let val: Result<hlua::UserdataOnStack<Foo, _>, _> =
                 hlua::LuaRead::lua_read_at_position(lua, index);
             val.map(|d| d.clone())
         }
@@ -50,7 +50,7 @@ fn destructor_called() {
     {
         type Err = hlua::Void;
         fn push_to_lua(self, lua: L) -> Result<hlua::PushGuard<L>, (hlua::Void, L)> {
-            Ok(hlua::userdata::push_userdata(self, lua, |_| {}))
+            Ok(hlua::push_userdata(self, lua, |_| {}))
         }
     }
 
@@ -72,14 +72,14 @@ fn type_check() {
     {
         type Err = hlua::Void;
         fn push_to_lua(self, lua: L) -> Result<hlua::PushGuard<L>, (hlua::Void, L)> {
-            Ok(hlua::userdata::push_userdata(self, lua, |_| {}))
+            Ok(hlua::push_userdata(self, lua, |_| {}))
         }
     }
     impl<'lua, L> hlua::LuaRead<L> for Foo
         where L: hlua::AsMutLua<'lua>
     {
         fn lua_read_at_position(lua: L, index: i32) -> Result<Foo, L> {
-            let val: Result<hlua::userdata::UserdataOnStack<Foo, _>, _> =
+            let val: Result<hlua::UserdataOnStack<Foo, _>, _> =
                 hlua::LuaRead::lua_read_at_position(lua, index);
             val.map(|d| d.clone())
         }
@@ -92,14 +92,14 @@ fn type_check() {
     {
         type Err = hlua::Void;
         fn push_to_lua(self, lua: L) -> Result<hlua::PushGuard<L>, (hlua::Void, L)> {
-            Ok(hlua::userdata::push_userdata(self, lua, |_| {}))
+            Ok(hlua::push_userdata(self, lua, |_| {}))
         }
     }
     impl<'lua, L> hlua::LuaRead<L> for Bar
         where L: hlua::AsMutLua<'lua>
     {
         fn lua_read_at_position(lua: L, index: i32) -> Result<Bar, L> {
-            let val: Result<hlua::userdata::UserdataOnStack<Bar, _>, _> =
+            let val: Result<hlua::UserdataOnStack<Bar, _>, _> =
                 hlua::LuaRead::lua_read_at_position(lua, index);
             val.map(|d| d.clone())
         }
@@ -122,7 +122,7 @@ fn metatables() {
     {
         type Err = hlua::Void;
         fn push_to_lua(self, lua: L) -> Result<hlua::PushGuard<L>, (hlua::Void, L)> {
-            Ok(hlua::userdata::push_userdata(self, lua, |mut table| {
+            Ok(hlua::push_userdata(self, lua, |mut table| {
                 table.set("__index".to_string(),
                           vec![("test".to_string(), hlua::function0(|| 5))]);
             }))


### PR DESCRIPTION
This is much less cumbersome in my opinion.