### PR TITLE
Small changes to the rust-hl-lua-modules crate

### DIFF
--- a/rust-hl-lua-modules/Cargo.toml
+++ b/rust-hl-lua-modules/Cargo.toml
@@ -9,5 +9,5 @@ name = "rust_hl_lua_modules"
 crate_type = ["dylib"]
 plugin = true
 
-[dependencies.rust-hl-lua]
-path = "../rust-hl-lua"
+[dependencies.hlua]
+path = "../hlua"

--- a/rust-hl-lua-modules/README.md
+++ b/rust-hl-lua-modules/README.md
@@ -1,0 +1,7 @@
+# Note
+
+This crate doesn't compile.
+
+In order to work it needs to use compiler plugins, which are still unstable in Rust.
+In addition to this the crate hasn't been updated for more than a year, so even if you use a
+nightly version of Rust it still won't compile.


### PR DESCRIPTION
Adds a README with a warning, and tweaks the Cargo.toml in an attempt to fix https://github.com/rust-lang/cargo/issues/3441