### PR TITLE
Implement reading HashMap

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,15 +193,15 @@ indices not starting at 1, `.get()` will return `None`, as Rust's
 It is possible to read a `HashMap<AnyHashableLuaValue, AnyLuaValue>`:
 
 ```rust
-        let mut lua = Lua::new();
+let mut lua = Lua::new();
 
-        lua.execute::<()>(r#"v = { [-1] = -1, ["foo"] = 2, [2.] = 42 }"#).unwrap();
+lua.execute::<()>(r#"v = { [-1] = -1, ["foo"] = 2, [2.] = 42 }"#).unwrap();
 
-        let read: HashMap<_, _> = lua.get("v").unwrap();
-        assert_eq!(read[&AnyHashableLuaValue::LuaNumber(-1)], AnyLuaValue::LuaNumber(-1.));
-        assert_eq!(read[&AnyHashableLuaValue::LuaString("foo".to_owned())], AnyLuaValue::LuaNumber(2.));
-        assert_eq!(read[&AnyHashableLuaValue::LuaNumber(2)], AnyLuaValue::LuaNumber(42.));
-        assert_eq!(read.len(), 3);
+let read: HashMap<_, _> = lua.get("v").unwrap();
+assert_eq!(read[&AnyHashableLuaValue::LuaNumber(-1)], AnyLuaValue::LuaNumber(-1.));
+assert_eq!(read[&AnyHashableLuaValue::LuaString("foo".to_owned())], AnyLuaValue::LuaNumber(2.));
+assert_eq!(read[&AnyHashableLuaValue::LuaNumber(2)], AnyLuaValue::LuaNumber(42.));
+assert_eq!(read.len(), 3);
 ```
 
 #### User data

--- a/README.md
+++ b/README.md
@@ -150,6 +150,8 @@ It is possible to read and write whole Rust containers at once:
 
 ```rust
 lua.set("a", [ 12, 13, 14, 15 ]);
+let hashmap: HashMap<i32, f64> = [1., 2., 3.].into_iter().enumerate().map(|(k, v)| (k as i32, *v as f64)).collect();
+lua.set("v", hashmap);
 ```
 
 If the container has single elements, then the indices will be numerical. For example in the code above, the `12` will be at index `1`, the `13` at index `2`, etc.
@@ -187,6 +189,20 @@ It is possible to read a `Vec<AnyLuaValue>`:
 In case table represents sparse array, has non-numeric keys, or
 indices not starting at 1, `.get()` will return `None`, as Rust's
 `Vec` doesn't support these features.
+
+It is possible to read a `HashMap<AnyHashableLuaValue, AnyLuaValue>`:
+
+```rust
+        let mut lua = Lua::new();
+
+        lua.execute::<()>(r#"v = { [-1] = -1, ["foo"] = 2, [2.] = 42 }"#).unwrap();
+
+        let read: HashMap<_, _> = lua.get("v").unwrap();
+        assert_eq!(read[&AnyHashableLuaValue::LuaNumber(-1)], AnyLuaValue::LuaNumber(-1.));
+        assert_eq!(read[&AnyHashableLuaValue::LuaString("foo".to_owned())], AnyLuaValue::LuaNumber(2.));
+        assert_eq!(read[&AnyHashableLuaValue::LuaNumber(2)], AnyLuaValue::LuaNumber(42.));
+        assert_eq!(read.len(), 3);
+```
 
 #### User data
 

--- a/hlua/src/any.rs
+++ b/hlua/src/any.rs
@@ -9,8 +9,23 @@ use PushOne;
 use LuaRead;
 use Void;
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub struct AnyLuaString(pub Vec<u8>);
+
+/// Represents any value that can be stored by Lua
+#[derive(Clone, Debug, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub enum AnyHashableLuaValue {
+    LuaString(String),
+    LuaAnyString(AnyLuaString),
+    LuaNumber(i32),
+    LuaBoolean(bool),
+    LuaArray(Vec<(AnyHashableLuaValue, AnyHashableLuaValue)>),
+    LuaNil,
+
+    /// The "Other" element is (hopefully) temporary and will be replaced by "Function" and "Userdata".
+    /// A panic! will trigger if you try to push a Other.
+    LuaOther,
+}
 
 /// Represents any value that can be stored by Lua
 #[derive(Clone, Debug, PartialEq)]
@@ -112,10 +127,96 @@ impl<'lua, L> LuaRead<L> for AnyLuaValue
     }
 }
 
+impl<'lua, L> Push<L> for AnyHashableLuaValue
+    where L: AsMutLua<'lua>
+{
+    type Err = Void;      // TODO: use `!` instead (https://github.com/rust-lang/rust/issues/35121)
+
+    #[inline]
+    fn push_to_lua(self, mut lua: L) -> Result<PushGuard<L>, (Void, L)> {
+        let raw_lua = lua.as_lua();
+        match self {
+            AnyHashableLuaValue::LuaString(val) => val.push_to_lua(lua),
+            AnyHashableLuaValue::LuaAnyString(val) => val.push_to_lua(lua),
+            AnyHashableLuaValue::LuaNumber(val) => val.push_to_lua(lua),
+            AnyHashableLuaValue::LuaBoolean(val) => val.push_to_lua(lua),
+            AnyHashableLuaValue::LuaArray(val) => {
+                // Pushing a `Vec<(AnyHashableLuaValue, AnyHashableLuaValue)>` on a `L` requires calling the
+                // function that pushes a `AnyHashableLuaValue` on a `&mut L`, which in turns requires
+                // calling the function that pushes a `AnyHashableLuaValue` on a `&mut &mut L`, and so on.
+                // In order to avoid this infinite recursion, we push the array on a
+                // `&mut AsMutLua` instead.
+
+                // We also need to destroy and recreate the push guard, otherwise the type parameter
+                // doesn't match.
+                let size = val.push_no_err(&mut lua as &mut AsMutLua<'lua>).forget();
+
+                Ok(PushGuard {
+                    lua: lua,
+                    size: size,
+                    raw_lua: raw_lua,
+                })
+            }
+            AnyHashableLuaValue::LuaNil => {
+                unsafe {
+                    ffi::lua_pushnil(lua.as_mut_lua().0);
+                }
+                Ok(PushGuard {
+                    lua: lua,
+                    size: 1,
+                    raw_lua: raw_lua,
+                })
+            } // Use ffi::lua_pushnil.
+            AnyHashableLuaValue::LuaOther => panic!("can't push a AnyHashableLuaValue of type Other"),
+        }
+    }
+}
+
+impl<'lua, L> PushOne<L> for AnyHashableLuaValue where L: AsMutLua<'lua> {}
+
+impl<'lua, L> LuaRead<L> for AnyHashableLuaValue
+    where L: AsLua<'lua>
+{
+    #[inline]
+    fn lua_read_at_position(lua: L, index: i32) -> Result<AnyHashableLuaValue, L> {
+        let lua = match LuaRead::lua_read_at_position(&lua, index) {
+            Ok(v) => return Ok(AnyHashableLuaValue::LuaNumber(v)),
+            Err(lua) => lua,
+        };
+
+        let lua = match LuaRead::lua_read_at_position(&lua, index) {
+            Ok(v) => return Ok(AnyHashableLuaValue::LuaBoolean(v)),
+            Err(lua) => lua,
+        };
+
+        let lua = match LuaRead::lua_read_at_position(&lua, index) {
+            Ok(v) => return Ok(AnyHashableLuaValue::LuaString(v)),
+            Err(lua) => lua,
+        };
+
+        let lua = match LuaRead::lua_read_at_position(&lua, index) {
+            Ok(v) => return Ok(AnyHashableLuaValue::LuaAnyString(v)),
+            Err(lua) => lua,
+        };
+
+        if unsafe { ffi::lua_isnil(lua.as_lua().0, index) } {
+            return Ok(AnyHashableLuaValue::LuaNil);
+        }
+
+        // let _lua = match LuaRead::lua_read_at_position(&lua, index) {
+        // Ok(v) => return Ok(AnyHashableLuaValue::LuaArray(v)),
+        // Err(lua) => lua
+        // };
+
+        Ok(AnyHashableLuaValue::LuaOther)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use Lua;
     use AnyLuaValue;
+    use AnyHashableLuaValue;
     use AnyLuaString;
 
     #[test]
@@ -130,6 +231,20 @@ mod tests {
 
         let y: AnyLuaValue = lua.get("b").unwrap();
         assert_eq!(y, AnyLuaValue::LuaNumber(3.5));
+    }
+
+    #[test]
+    fn read_hashable_numbers() {
+        let mut lua = Lua::new();
+
+        lua.set("a", "-2");
+        lua.set("b", "4");
+
+        let x: AnyHashableLuaValue = lua.get("a").unwrap();
+        assert_eq!(x, AnyHashableLuaValue::LuaNumber(-2));
+
+        let y: AnyHashableLuaValue = lua.get("b").unwrap();
+        assert_eq!(y, AnyHashableLuaValue::LuaNumber(4));
     }
 
     #[test]
@@ -151,6 +266,24 @@ mod tests {
     }
 
     #[test]
+    fn read_hashable_strings() {
+        let mut lua = Lua::new();
+
+        lua.set("a", "hello");
+        lua.set("b", "3x");
+        lua.set("c", "false");
+
+        let x: AnyHashableLuaValue = lua.get("a").unwrap();
+        assert_eq!(x, AnyHashableLuaValue::LuaString("hello".to_string()));
+
+        let y: AnyHashableLuaValue = lua.get("b").unwrap();
+        assert_eq!(y, AnyHashableLuaValue::LuaString("3x".to_string()));
+
+        let z: AnyHashableLuaValue = lua.get("c").unwrap();
+        assert_eq!(z, AnyHashableLuaValue::LuaString("false".to_string()));
+    }
+
+    #[test]
     fn read_booleans() {
         let mut lua = Lua::new();
 
@@ -165,10 +298,34 @@ mod tests {
     }
 
     #[test]
+    fn read_hashable_booleans() {
+        let mut lua = Lua::new();
+
+        lua.set("a", true);
+        lua.set("b", false);
+
+        let x: AnyHashableLuaValue = lua.get("a").unwrap();
+        assert_eq!(x, AnyHashableLuaValue::LuaBoolean(true));
+
+        let y: AnyHashableLuaValue = lua.get("b").unwrap();
+        assert_eq!(y, AnyHashableLuaValue::LuaBoolean(false));
+    }
+
+    #[test]
     fn push_numbers() {
         let mut lua = Lua::new();
 
         lua.set("a", AnyLuaValue::LuaNumber(3.0));
+
+        let x: i32 = lua.get("a").unwrap();
+        assert_eq!(x, 3);
+    }
+
+    #[test]
+    fn push_hashable_numbers() {
+        let mut lua = Lua::new();
+
+        lua.set("a", AnyHashableLuaValue::LuaNumber(3));
 
         let x: i32 = lua.get("a").unwrap();
         assert_eq!(x, 3);
@@ -185,10 +342,30 @@ mod tests {
     }
 
     #[test]
+    fn push_hashable_strings() {
+        let mut lua = Lua::new();
+
+        lua.set("a", AnyHashableLuaValue::LuaString("hello".to_string()));
+
+        let x: String = lua.get("a").unwrap();
+        assert_eq!(x, "hello");
+    }
+
+    #[test]
     fn push_booleans() {
         let mut lua = Lua::new();
 
         lua.set("a", AnyLuaValue::LuaBoolean(true));
+
+        let x: bool = lua.get("a").unwrap();
+        assert_eq!(x, true);
+    }
+
+    #[test]
+    fn push_hashable_booleans() {
+        let mut lua = Lua::new();
+
+        lua.set("a", AnyHashableLuaValue::LuaBoolean(true));
 
         let x: bool = lua.get("a").unwrap();
         assert_eq!(x, true);
@@ -206,6 +383,17 @@ mod tests {
                 x);
     }
 
+    #[test]
+    fn push_hashable_nil() {
+        let mut lua = Lua::new();
+
+        lua.set("a", AnyHashableLuaValue::LuaNil);
+
+        let x: Option<i32> = lua.get("a");
+        assert!(x.is_none(),
+                "x is a Some value when it should be a None value. X: {:?}",
+                x);
+    }
 
     #[test]
     fn non_utf_8_string() {

--- a/hlua/src/lib.rs
+++ b/hlua/src/lib.rs
@@ -118,7 +118,7 @@ use std::fmt;
 use std::convert::From;
 use std::io;
 
-pub use any::{AnyLuaValue, AnyLuaString};
+pub use any::{AnyHashableLuaValue, AnyLuaString, AnyLuaValue};
 pub use functions_write::{Function, InsideCallback};
 pub use functions_write::{function0, function1, function2, function3, function4, function5};
 pub use functions_write::{function6, function7, function8, function9, function10};

--- a/hlua/src/rust_tables.rs
+++ b/hlua/src/rust_tables.rs
@@ -194,6 +194,7 @@ impl<'a, 'lua, L, T, E> PushOne<L> for &'a [T]
 impl<'lua, L> LuaRead<L> for HashMap<AnyHashableLuaValue, AnyLuaValue>
     where L: AsMutLua<'lua>
 {
+    // TODO: this should be implemented using the LuaTable API instead of raw Lua calls.
     fn lua_read_at_position(lua: L, index: i32) -> Result<Self, L> {
         let mut me = lua;
         unsafe { ffi::lua_pushnil(me.as_mut_lua().0) };

--- a/hlua/src/rust_tables.rs
+++ b/hlua/src/rust_tables.rs
@@ -119,9 +119,7 @@ impl<'lua, L> LuaRead<L> for Vec<AnyLuaValue>
                 break;
             }
 
-            let key;
-
-            {
+            let key = {
                 let maybe_key: Option<i32> =
                     LuaRead::lua_read_at_position(&mut me, -2).ok();
                 match maybe_key {
@@ -130,9 +128,9 @@ impl<'lua, L> LuaRead<L> for Vec<AnyLuaValue>
                         unsafe { ffi::lua_pop(me.as_mut_lua().0, 2) };
                         return Err(me)
                     }
-                    Some(k) => key = k,
+                    Some(k) => k,
                 }
-            }
+            };
 
             let value: AnyLuaValue =
                 LuaRead::lua_read_at_position(&mut me, -1).ok().unwrap();

--- a/hlua/src/rust_tables.rs
+++ b/hlua/src/rust_tables.rs
@@ -1,5 +1,5 @@
 use ffi;
-use any::AnyLuaValue;
+use any::{AnyLuaValue, AnyHashableLuaValue};
 
 use Push;
 use PushGuard;
@@ -191,6 +191,45 @@ impl<'a, 'lua, L, T, E> PushOne<L> for &'a [T]
 {
 }
 
+impl<'lua, L> LuaRead<L> for HashMap<AnyHashableLuaValue, AnyLuaValue>
+    where L: AsMutLua<'lua>
+{
+    fn lua_read_at_position(lua: L, index: i32) -> Result<Self, L> {
+        let mut me = lua;
+        unsafe { ffi::lua_pushnil(me.as_mut_lua().0) };
+        let index = index - 1;
+        let mut result = HashMap::new();
+
+        loop {
+            if unsafe { ffi::lua_next(me.as_mut_lua().0, index) } == 0 {
+                break;
+            }
+
+            let key = {
+                let maybe_key: Option<AnyHashableLuaValue> =
+                    LuaRead::lua_read_at_position(&mut me, -2).ok();
+                match maybe_key {
+                    None => {
+                        // Cleaning up after ourselves
+                        unsafe { ffi::lua_pop(me.as_mut_lua().0, 2) };
+                        return Err(me)
+                    }
+                    Some(k) => k,
+                }
+            };
+
+            let value: AnyLuaValue =
+                LuaRead::lua_read_at_position(&mut me, -1).ok().unwrap();
+
+            unsafe { ffi::lua_pop(me.as_mut_lua().0, 1) };
+
+            result.insert(key, value);
+        }
+
+        Ok(result)
+    }
+}
+
 // TODO: use an enum for the error to allow different error types for K and V
 impl<'lua, L, K, V, E> Push<L> for HashMap<K, V>
     where L: AsMutLua<'lua>,
@@ -240,11 +279,11 @@ impl<'lua, L, K, E> PushOne<L> for HashSet<K>
 
 #[cfg(test)]
 mod tests {
-    use std::collections::HashMap;
-    use std::collections::HashSet;
+    use std::collections::{HashMap, HashSet, BTreeMap};
     use Lua;
     use LuaTable;
     use AnyLuaValue;
+    use AnyHashableLuaValue;
 
     #[test]
     fn write() {
@@ -393,5 +432,109 @@ mod tests {
             read,
             [1., 2., 3.].iter()
                 .map(|x| AnyLuaValue::LuaNumber(*x)).collect::<Vec<_>>());
+    }
+
+    #[test]
+    fn reading_hashmap_works() {
+        let mut lua = Lua::new();
+
+        let orig: HashMap<i32, f64> = [1., 2., 3.].into_iter().enumerate().map(|(k, v)| (k as i32, *v as f64)).collect();
+        let orig_copy = orig.clone();
+        // Collect to BTreeMap so that iterator yields values in order
+        let orig_btree: BTreeMap<_, _> = orig_copy.into_iter().collect();
+
+        lua.set("v", orig);
+
+        let read: HashMap<AnyHashableLuaValue, AnyLuaValue> = lua.get("v").unwrap();
+        // Same as above
+        let read_btree: BTreeMap<_, _> = read.into_iter().collect();
+        for (o, r) in orig_btree.iter().zip(read_btree.iter()) {
+            if let (&AnyHashableLuaValue::LuaNumber(i), &AnyLuaValue::LuaNumber(n)) = r {
+                let (&o_i, &o_n) = o;
+                assert_eq!(o_i, i);
+                assert_eq!(o_n, n);
+            } else {
+                panic!("Unexpected variant");
+            }
+        }
+    }
+
+    #[test]
+    fn reading_hashmap_from_sparse_table_works() {
+        let mut lua = Lua::new();
+
+        lua.execute::<()>(r#"v = { [-1] = -1, [2] = 2, [42] = 42 }"#).unwrap();
+
+        let read: HashMap<_, _> = lua.get("v").unwrap();
+        assert_eq!(read[&AnyHashableLuaValue::LuaNumber(-1)], AnyLuaValue::LuaNumber(-1.));
+        assert_eq!(read[&AnyHashableLuaValue::LuaNumber(2)], AnyLuaValue::LuaNumber(2.));
+        assert_eq!(read[&AnyHashableLuaValue::LuaNumber(42)], AnyLuaValue::LuaNumber(42.));
+        assert_eq!(read.len(), 3);
+    }
+
+    #[test]
+    fn reading_hashmap_with_empty_table_works() {
+        let mut lua = Lua::new();
+
+        lua.execute::<()>(r#"v = { }"#).unwrap();
+
+        let read: HashMap<_, _> = lua.get("v").unwrap();
+        assert_eq!(read.len(), 0);
+    }
+
+    #[test]
+    fn reading_hashmap_with_complex_indexes_works() {
+        let mut lua = Lua::new();
+
+        lua.execute::<()>(r#"v = { [-1] = -1, ["foo"] = 2, [2.] = 42 }"#).unwrap();
+
+        let read: HashMap<_, _> = lua.get("v").unwrap();
+        assert_eq!(read[&AnyHashableLuaValue::LuaNumber(-1)], AnyLuaValue::LuaNumber(-1.));
+        assert_eq!(read[&AnyHashableLuaValue::LuaString("foo".to_owned())], AnyLuaValue::LuaNumber(2.));
+        assert_eq!(read[&AnyHashableLuaValue::LuaNumber(2)], AnyLuaValue::LuaNumber(42.));
+        assert_eq!(read.len(), 3);
+    }
+
+    #[test]
+    fn reading_hashmap_with_floating_indexes_works() {
+        let mut lua = Lua::new();
+
+        lua.execute::<()>(r#"v = { [-1.25] = -1, [2.5] = 42 }"#).unwrap();
+
+        let read: HashMap<_, _> = lua.get("v").unwrap();
+        // It works by truncating integers in some unspecified way
+        // https://www.lua.org/manual/5.2/manual.html#lua_tointegerx
+        assert_eq!(read[&AnyHashableLuaValue::LuaNumber(-1)], AnyLuaValue::LuaNumber(-1.));
+        assert_eq!(read[&AnyHashableLuaValue::LuaNumber(2)], AnyLuaValue::LuaNumber(42.));
+        assert_eq!(read.len(), 2);
+    }
+
+    #[test]
+    fn reading_heterogenous_hashmap_works() {
+        let mut lua = Lua::new();
+
+        let mut orig = HashMap::new();
+        orig.insert(AnyHashableLuaValue::LuaNumber(42), AnyLuaValue::LuaNumber(42.));
+        orig.insert(AnyHashableLuaValue::LuaString("foo".to_owned()), AnyLuaValue::LuaString("foo".to_owned()));
+        orig.insert(AnyHashableLuaValue::LuaBoolean(true), AnyLuaValue::LuaBoolean(true));
+
+        let orig_clone = orig.clone();
+        lua.set("v", orig);
+
+        let read: HashMap<_, _> = lua.get("v").unwrap();
+        assert_eq!(read, orig_clone);
+    }
+
+    #[test]
+    fn reading_hashmap_set_from_lua_works() {
+        let mut lua = Lua::new();
+
+        lua.execute::<()>(r#"v = { [1] = 2, [2] = 3, [3] = 4 }"#).unwrap();
+
+        let read: HashMap<_, _> = lua.get("v").unwrap();
+        assert_eq!(
+            read,
+            [2., 3., 4.].iter().enumerate()
+                .map(|(k, v)| (AnyHashableLuaValue::LuaNumber((k + 1) as i32), AnyLuaValue::LuaNumber(*v))).collect::<HashMap<_, _>>());
     }
 }


### PR DESCRIPTION
As it's impossible to `Eq` and `Hash` `f64`, I decided to split `AnyLuaValue`. I duplicated all variants instead of putting `AnyHashableLuaValue` inside of `AnyLuaValue` as that removes nesting, that would occur otherwise when handling `AnyHashableLuaValue`s produced by reading `HashMap`.

Close #9 