### PR TITLE
allow getting at the Lua state from a Lua object

### DIFF
--- a/hlua/src/lib.rs
+++ b/hlua/src/lib.rs
@@ -107,6 +107,7 @@
 
 // Export the version of lua52_sys in use by this crate. This allows clients to perform low-level
 // Lua operations without worrying about semver.
+#[doc(hidden)]
 pub extern crate lua52_sys as ffi;
 extern crate libc;
 
@@ -257,6 +258,21 @@ pub unsafe trait AsMutLua<'lua>: AsLua<'lua> {
 // TODO: probably no longer necessary
 #[derive(Copy, Clone, Debug)]
 pub struct LuaContext(*mut ffi::lua_State);
+
+impl LuaContext {
+    /// Return a pointer to the inner `lua_State` for this context. This is an escape hatch that
+    /// lets the caller perform arbitrary operations against the FFI directly.
+    ///
+    /// Be careful: performing operations on this state might invalidate assumptions made in
+    /// higher-level APIs. For example, pushing a value onto the Lua stack will cause `PushGuard`s
+    /// in Rust code to be out of sync with the Lua stack.
+    #[doc(hidden)]
+    #[inline]
+    pub fn state_ptr(&self) -> *mut ffi::lua_State {
+        self.0
+    }
+}
+
 unsafe impl Send for LuaContext {}
 
 unsafe impl<'a, 'lua> AsLua<'lua> for Lua<'lua> {

--- a/hlua/src/lib.rs
+++ b/hlua/src/lib.rs
@@ -105,7 +105,9 @@
 //! - TODO: userdata
 //!
 
-extern crate lua52_sys as ffi;
+// Export the version of lua52_sys in use by this crate. This allows clients to perform low-level
+// Lua operations without worrying about semver.
+pub extern crate lua52_sys as ffi;
 extern crate libc;
 
 use std::ffi::{CStr, CString};

--- a/hlua/tests/ffi.rs
+++ b/hlua/tests/ffi.rs
@@ -1,0 +1,15 @@
+//! Test to make sure the low-level API can be accessed from hlua.
+
+extern crate hlua;
+
+use hlua::AsLua;
+
+#[test]
+fn get_version() {
+    let lua = hlua::Lua::new();
+    let state_ptr = lua.as_lua().state_ptr();
+
+    let version = unsafe { *hlua::ffi::lua_version(state_ptr) as i32 };
+    // 502 = Lua 5.2
+    assert_eq!(version, 502);
+}


### PR DESCRIPTION
This is most useful when the caller wants to do low-level operations on
the state that aren't supported through the main API.