### PR TITLE
Store index with UserdataOnStack so that correct value is read in Deref

### DIFF
--- a/hlua/src/any.rs
+++ b/hlua/src/any.rs
@@ -131,7 +131,7 @@ impl<'lua, L> LuaRead<L> for AnyLuaValue
                 Err(lua) => lua,
             };
 
-            let mut lua = match LuaRead::lua_read_at_position(&mut lua as &mut AsMutLua<'lua>, index) {
+            let lua = match LuaRead::lua_read_at_position(&mut lua as &mut AsMutLua<'lua>, index) {
                 Ok(v) => return Ok(AnyLuaValue::LuaAnyString(v)),
                 Err(lua) => lua,
             };

--- a/hlua/src/functions_write.rs
+++ b/hlua/src/functions_write.rs
@@ -365,7 +365,7 @@ impl<'a, T, E, P> Push<&'a mut InsideCallback> for Result<T, E>
     type Err = P;
 
     #[inline]
-    fn push_to_lua(self, mut lua: &'a mut InsideCallback) -> Result<PushGuard<&'a mut InsideCallback>, (P, &'a mut InsideCallback)> {
+    fn push_to_lua(self, lua: &'a mut InsideCallback) -> Result<PushGuard<&'a mut InsideCallback>, (P, &'a mut InsideCallback)> {
         match self {
             Ok(val) => val.push_to_lua(lua),
             Err(val) => {

--- a/hlua/tests/userdata.rs
+++ b/hlua/tests/userdata.rs
@@ -141,3 +141,84 @@ fn metatables() {
     let x: i32 = lua.execute("return a.test()").unwrap();
     assert_eq!(x, 5);
 }
+
+#[test]
+fn multiple_userdata() {
+    #[derive(Clone)]
+    struct Integer(u32);
+    impl<'lua, L> hlua::Push<L> for Integer
+        where L: hlua::AsMutLua<'lua>
+    {
+        type Err = hlua::Void;
+        fn push_to_lua(self, lua: L) -> Result<hlua::PushGuard<L>, (hlua::Void, L)> {
+            Ok(hlua::push_userdata(self, lua, |_| { }))
+        }
+    }
+    impl<'lua, L> hlua::PushOne<L> for Integer where L: hlua::AsMutLua<'lua> {}
+    impl<'lua, L> hlua::LuaRead<L> for Integer
+        where L: hlua::AsMutLua<'lua>
+    {
+        fn lua_read_at_position(lua: L, index: i32) -> Result<Integer, L> {
+            let val: Result<hlua::UserdataOnStack<Integer, _>, _> =
+                hlua::LuaRead::lua_read_at_position(lua, index);
+            val.map(|d| d.clone())
+        }
+    }
+
+    #[derive(Debug, Clone, PartialEq, Eq)]
+    struct BigInteger(u32, u32, u32, u32);
+    impl<'lua, L> hlua::Push<L> for BigInteger
+        where L: hlua::AsMutLua<'lua>
+    {
+        type Err = hlua::Void;
+        fn push_to_lua(self, lua: L) -> Result<hlua::PushGuard<L>, (hlua::Void, L)> {
+            Ok(hlua::push_userdata(self, lua, |_| { }))
+        }
+    }
+    impl<'lua, L> hlua::PushOne<L> for BigInteger where L: hlua::AsMutLua<'lua> {}
+    impl<'lua, L> hlua::LuaRead<L> for BigInteger
+        where L: hlua::AsMutLua<'lua>
+    {
+        fn lua_read_at_position(lua: L, index: i32) -> Result<BigInteger, L> {
+            let val: Result<hlua::UserdataOnStack<BigInteger, _>, _> =
+                hlua::LuaRead::lua_read_at_position(lua, index);
+            val.map(|d| d.clone())
+        }
+    }
+
+    let axpy_float = |a: f64, x: Integer, y: Integer| a * x.0 as f64 + y.0 as f64;
+    let axpy_float_2 = |a: f64, x: Integer, y: f64| a * x.0 as f64 + y;
+    let broadcast_mul = |k: Integer, v: BigInteger|
+        BigInteger(k.0 * v.0, k.0 * v.1, k.0 * v.2, k.0 * v.3);
+    let collapse = |a: f32, k: Integer, v: BigInteger|
+        (k.0 * v.0) as f32 * a + (k.0 * v.1) as f32 * a + (k.0 * v.2) as f32 * a + (k.0 * v.3) as f32 * a;
+    let mut lua = hlua::Lua::new();
+
+    let big_integer = BigInteger(531,246,1,953);
+    lua.set("a", Integer(19));
+    lua.set("b", Integer(114));
+    lua.set("c", Integer(96));
+    lua.set("d", Integer(313));
+    lua.set("v", big_integer.clone());
+    lua.set("add", hlua::function2(|x: Integer, y: Integer| Integer(x.0 + y.0)));
+    lua.set("axpy", hlua::function3(|a: Integer, x: Integer, y: Integer|
+        Integer(a.0 * x.0 + y.0)));
+    lua.set("axpy_float", hlua::function3(&axpy_float));
+    lua.set("axpy_float_2", hlua::function3(&axpy_float_2));
+    lua.set("broadcast_mul", hlua::function2(&broadcast_mul));
+    lua.set("collapse", hlua::function3(&collapse));
+
+    assert_eq!(lua.execute::<Integer>("return add(a, b)").unwrap().0, 19 + 114);
+    assert_eq!(lua.execute::<Integer>("return add(b, c)").unwrap().0, 114 + 96);
+    assert_eq!(lua.execute::<Integer>("return add(c, d)").unwrap().0, 96 + 313);
+    assert_eq!(lua.execute::<Integer>("return axpy(a, b, c)").unwrap().0, 19 * 114 + 96);
+    assert_eq!(lua.execute::<Integer>("return axpy(b, c, d)").unwrap().0, 114 * 96 + 313);
+    assert_eq!(lua.execute::<f64>("return axpy_float(2.5, c, d)").unwrap(),
+        axpy_float(2.5, Integer(96), Integer(313)));
+    assert_eq!(lua.execute::<BigInteger>("return broadcast_mul(a, v)").unwrap(),
+        broadcast_mul(Integer(19), big_integer.clone()));
+    assert_eq!(lua.execute::<BigInteger>("return broadcast_mul(b, v)").unwrap(),
+        broadcast_mul(Integer(114), big_integer.clone()));
+    assert_eq!(lua.execute::<f32>("return collapse(19.25, c, v)").unwrap(),
+        collapse(19.25, Integer(96), big_integer.clone()));
+}


### PR DESCRIPTION
the `Deref` and `DerefMut` impls previously always read from the index -1, which would be incorrect if the userdata were stored elsewhere. This adds an `index` field to `UserdataOnStack` which is filled in when it is created in `lua_read_at_position`, so that the value is always read from the correct position. This allows having userdata in function arguments aside from the first, for example.