### PR TITLE
Bump hlua to 0.4.2

### DIFF
--- a/hlua/Cargo.toml
+++ b/hlua/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hlua"
-version = "0.4.1"
+version = "0.4.2"
 authors = [ "pierre.krieger1708@gmail.com" ]
 description = "Zero-cost high-level wrapper for Lua"
 keywords = ["lua"]


### PR DESCRIPTION
In the same way as #202 I would like to suggest a new release of the hlua crate. If necessary we can change this to 0.5.0.