### PR TITLE
Use `slice::iter` instead of `into_iter` to avoid future breakage

### DIFF
--- a/hlua/src/rust_tables.rs
+++ b/hlua/src/rust_tables.rs
@@ -439,7 +439,7 @@ mod tests {
     fn reading_hashmap_works() {
         let mut lua = Lua::new();
 
-        let orig: HashMap<i32, f64> = [1., 2., 3.].into_iter().enumerate().map(|(k, v)| (k as i32, *v as f64)).collect();
+        let orig: HashMap<i32, f64> = [1., 2., 3.].iter().enumerate().map(|(k, v)| (k as i32, *v as f64)).collect();
         let orig_copy = orig.clone();
         // Collect to BTreeMap so that iterator yields values in order
         let orig_btree: BTreeMap<_, _> = orig_copy.into_iter().collect();


### PR DESCRIPTION
Use `slice::iter` instead of `into_iter` to avoid future breakage

`an_array.into_iter()` currently just works because of the autoref
feature, which then calls `<[T] as IntoIterator>::into_iter`. But
in the future, arrays will implement `IntoIterator`, too. In order
to avoid problems in the future, the call is replaced by `iter()`
which is shorter and more explicit.

A crater run showed that your crate is affected by a potential future 
change. See https://github.com/rust-lang/rust/pull/65819 for more information.
