### PR TITLE
Fixed segfault when deref unaligned typeid

### DIFF
--- a/hlua/src/userdata.rs
+++ b/hlua/src/userdata.rs
@@ -136,7 +136,7 @@ where
         }
 
         let actual_typeid = data_ptr as *const TypeId;
-        if *actual_typeid != TypeId::of::<T>() {
+        if ptr::read_unaligned(actual_typeid) != TypeId::of::<T>() {
             return Err(lua);
         }
 
@@ -167,7 +167,7 @@ where
             }
 
             let actual_typeid = data_ptr as *const TypeId;
-            if *actual_typeid != TypeId::of::<T>() {
+            if ptr::read_unaligned(actual_typeid) != TypeId::of::<T>() {
                 return Err(lua);
             }
 


### PR DESCRIPTION
Fixed #219.

So I went on a bit of a journey in the #219 issue.

In conclusion, the address returned by `ffi::lua_newuserdata()` might be unaligned, which causes dereferencing `actual_typeid` to segfault due to a potential unaligned pointer. Changing it to allow for unaligned reads, results in all tests and all examples succeeding without segfaulting.

_I'm unsure if the subsequent `*data` can ever be unaligned. But I didn't run into it so far._

